### PR TITLE
s2180, ta8647: getSchema changed to getScheme. Version upped to 1.0.16

### DIFF
--- a/cadc-util/build.gradle
+++ b/cadc-util/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.0.15'
+version = '1.0.16'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/cadc-util/src/main/java/ca/nrc/cadc/net/StorageResolver.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/net/StorageResolver.java
@@ -80,11 +80,11 @@ import java.net.URL;
 public interface StorageResolver
 {
     /**
-     * Returns the schema for the storage resolver. 
+     * Returns the scheme for the storage resolver.
      * 
      * @return a String representing the schema.
      */
-    public String getSchema();
+    public String getScheme();
     
     /**
      * Convert the specified URI to one or more URL(s). 


### PR DESCRIPTION
Needs to be released so work for MAST and Gemini resolvers (caom2-artifact-resolvers) can continue sanely.