### PR TITLE
Fixes https://github.com/opencadc/ac/issues/50

### DIFF
--- a/cadc-util/build.gradle
+++ b/cadc-util/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'maven'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.7.1'
+    id 'com.jfrog.bintray' version '1.8.0'
 }
 
 repositories {
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.2'
+version = '1.1.3'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/cadc-util/src/main/java/ca/nrc/cadc/auth/DelegationToken.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/auth/DelegationToken.java
@@ -1,71 +1,71 @@
 /*
-************************************************************************
-*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
-**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
-*
-*  (c) 2018.                            (c) 2018.
-*  Government of Canada                 Gouvernement du Canada
-*  National Research Council            Conseil national de recherches
-*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-*  All rights reserved                  Tous droits réservés
-*
-*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
-*  expressed, implied, or               énoncée, implicite ou légale,
-*  statutory, of any kind with          de quelque nature que ce
-*  respect to the software,             soit, concernant le logiciel,
-*  including without limitation         y compris sans restriction
-*  any warranty of merchantability      toute garantie de valeur
-*  or fitness for a particular          marchande ou de pertinence
-*  purpose. NRC shall not be            pour un usage particulier.
-*  liable in any event for any          Le CNRC ne pourra en aucun cas
-*  damages, whether direct or           être tenu responsable de tout
-*  indirect, special or general,        dommage, direct ou indirect,
-*  consequential or incidental,         particulier ou général,
-*  arising from the use of the          accessoire ou fortuit, résultant
-*  software.  Neither the name          de l'utilisation du logiciel. Ni
-*  of the National Research             le nom du Conseil National de
-*  Council of Canada nor the            Recherches du Canada ni les noms
-*  names of its contributors may        de ses  participants ne peuvent
-*  be used to endorse or promote        être utilisés pour approuver ou
-*  products derived from this           promouvoir les produits dérivés
-*  software without specific prior      de ce logiciel sans autorisation
-*  written permission.                  préalable et particulière
-*                                       par écrit.
-*
-*  This file is part of the             Ce fichier fait partie du projet
-*  OpenCADC project.                    OpenCADC.
-*
-*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
-*  you can redistribute it and/or       vous pouvez le redistribuer ou le
-*  modify it under the terms of         modifier suivant les termes de
-*  the GNU Affero General Public        la “GNU Affero General Public
-*  License as published by the          License” telle que publiée
-*  Free Software Foundation,            par la Free Software Foundation
-*  either version 3 of the              : soit la version 3 de cette
-*  License, or (at your option)         licence, soit (à votre gré)
-*  any later version.                   toute version ultérieure.
-*
-*  OpenCADC is distributed in the       OpenCADC est distribué
-*  hope that it will be useful,         dans l’espoir qu’il vous
-*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
-*  without even the implied             GARANTIE : sans même la garantie
-*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
-*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
-*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
-*  General Public License for           Générale Publique GNU Affero
-*  more details.                        pour plus de détails.
-*
-*  You should have received             Vous devriez avoir reçu une
-*  a copy of the GNU Affero             copie de la Licence Générale
-*  General Public License along         Publique GNU Affero avec
-*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
-*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
-*                                       <http://www.gnu.org/licenses/>.
-*
-*  $Revision: 5 $
-*
-************************************************************************
-*/
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2018.                            (c) 2018.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  $Revision: 5 $
+ *
+ ************************************************************************
+ */
 
 package ca.nrc.cadc.auth;
 
@@ -78,17 +78,21 @@ import java.security.InvalidKeyException;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Date;
+
 import ca.nrc.cadc.util.Base64;
 import ca.nrc.cadc.util.RsaSignatureGenerator;
 import ca.nrc.cadc.util.RsaSignatureVerifier;
 import ca.nrc.cadc.util.StringUtil;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import javax.security.auth.x500.X500Principal;
+
 import org.apache.log4j.Logger;
 
 /**
@@ -97,25 +101,28 @@ import org.apache.log4j.Logger;
  * - the user that delegates
  * - the expirty time
  * - scope of delegation
- *
+ * <p>
  * This class can serialize and de-serialize the information into a
  * String token. Optionally, it can sign the serialized token and
  * verify when one is received.
  */
-public class DelegationToken implements Serializable
-{
+public class DelegationToken implements Serializable {
     private static final Logger log = Logger.getLogger(DelegationToken.class);
 
-    private static final long serialVersionUID = 20180321000000l;
+    private static final long serialVersionUID = 20180321000000L;
 
     private Set<Principal> identityPrincipals;
 
     public static String PROXY_LABEL = "proxyuser";
     public static String SCOPE_LABEL = "scope";
     public static String DOMAIN_LABEL = "domain";
+
+    // Why not simply re-use the IdentityType.USERID.getValue() here rather than a yet another custom label?
     public static String USER_LABEL = "userid";
     public static String EXPIRY_LABEL = "expirytime";
     public static String SIGNATURE_LABEL = "signature";
+    public static String IDENTITIES_LABEL = "identities";
+
 
     private Date expiryTime; // expiration time of the delegation (UTC)
     private URI scope; // resources that are the object of the delegation
@@ -124,11 +131,9 @@ public class DelegationToken implements Serializable
     public static final String FIELD_DELIM = "&";
     public static final String VALUE_DELIM = "=";
 
-    public static class ScopeValidator
-    {
+    public static class ScopeValidator {
         public void verifyScope(URI scope, String requestURI)
-            throws InvalidDelegationTokenException
-        {
+            throws InvalidDelegationTokenException {
             throw new InvalidDelegationTokenException("default: invalid scope");
         }
     }
@@ -136,24 +141,21 @@ public class DelegationToken implements Serializable
     /**
      * Constructor.
      *
-     * @param user identity of the delegating user - required
-     * @param scope - scope of the delegation, i.e. resource that it applies
-     * to - optional
+     * @param user       identity of the delegating user - required
+     * @param scope      - scope of the delegation, i.e. resource that it applies
+     *                   to - optional
      * @param expiryTime - the expiry date of this token (UTC)
      */
-    public DelegationToken(HttpPrincipal user, URI scope, Date expiryTime, List<String> domains)
-    {
+    public DelegationToken(HttpPrincipal user, URI scope, Date expiryTime, List<String> domains) {
         // Validation of parameter means using this() to call
         // other constructor isn't possible.
-        if (user == null)
-        {
+        if (user == null) {
             throw new IllegalArgumentException("User identity required");
         }
 
         this.addPrincipal(user);
 
-        if(expiryTime == null)
-        {
+        if (expiryTime == null) {
             throw new IllegalArgumentException("No expiry time");
         }
         this.expiryTime = expiryTime;
@@ -164,20 +166,18 @@ public class DelegationToken implements Serializable
 
     /**
      * Constructor.
+     *
      * @param principals - sorted set of identity principals (http, x500, cadc)
-     * @param scope - scope of the delegation, i.e. resource that it applies to - optional
+     * @param scope      - scope of the delegation, i.e. resource that it applies to - optional
      * @param expiryTime - the expiry date of this token (UTC)
-     * @param domains - list of domains that this token could be used for
+     * @param domains    - list of domains that this token could be used for
      */
-    public DelegationToken(Set<Principal> principals, URI scope, Date expiryTime, List<String> domains)
-    {
-        if (principals == null || principals.size() == 0)
-        {
+    public DelegationToken(Set<Principal> principals, URI scope, Date expiryTime, List<String> domains) {
+        if (principals == null || principals.size() == 0) {
             throw new IllegalArgumentException("Identity principals required (ie http, x500, cadc internal)");
         }
 
-        if(expiryTime == null)
-        {
+        if (expiryTime == null) {
             throw new IllegalArgumentException("No expiry time");
         }
 
@@ -192,14 +192,13 @@ public class DelegationToken implements Serializable
      * Serializes and signs the object into a string of attribute-value pairs.
      *
      * @param token the token to format
-     * the returned string
+     *              the returned string
      * @return String with DelegationToken information
-     * @throws IOException
-     * @throws InvalidKeyException
+     * @throws IOException         IO problems
+     * @throws InvalidKeyException The provided key is invalid
      */
     public static String format(DelegationToken token)
-        throws InvalidKeyException, IOException
-    {
+        throws InvalidKeyException, IOException {
         StringBuilder sb = getContent(token);
 
         //sign and add the signature field
@@ -209,50 +208,28 @@ public class DelegationToken implements Serializable
         sb.append(SIGNATURE_LABEL);
         sb.append(VALUE_DELIM);
         RsaSignatureGenerator su = new RsaSignatureGenerator();
-        byte[] sig =
-                su.sign(new ByteArrayInputStream(toSign.getBytes()));
+        byte[] sig = su.sign(new ByteArrayInputStream(toSign.getBytes()));
         sb.append(new String(Base64.encode(sig)));
 
         return sb.toString();
     }
 
     // the formatted content without the signature
-    private static StringBuilder getContent(DelegationToken token)
-    {
+    private static StringBuilder getContent(DelegationToken token) {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(EXPIRY_LABEL + VALUE_DELIM);
+        sb.append(EXPIRY_LABEL).append(VALUE_DELIM);
         sb.append(token.getExpiryTime().getTime());
 
-        // Add all available identity principals to the content
-        for (Principal prin: token.identityPrincipals)
-        {
-            String principalName = prin.getClass().getSimpleName();
+        final Set<Principal> identityPrincipals = token.identityPrincipals;
 
-            IdentityType principalIdentity = IdentityType.principalIdentityMap.get(principalName);
-            if (principalIdentity.equals(IdentityType.ENTRY_DN))
-            {
-                // Do not add this for external use, to cookies, etc.
-                continue;
-            }
-
+        if (!identityPrincipals.isEmpty()) {
             sb.append(FIELD_DELIM);
-            sb.append(principalIdentity.getValue());
-            sb.append(VALUE_DELIM);
-            sb.append(prin.getName());
+            sb.append(IDENTITIES_LABEL).append(VALUE_DELIM);
+            sb.append(DelegationToken.encodePrincipals(identityPrincipals));
         }
 
-        HttpPrincipal user = token.getUser();
-        if (StringUtil.hasText(user.getProxyUser()))
-        {
-            sb.append(FIELD_DELIM);
-            sb.append(PROXY_LABEL);
-            sb.append(VALUE_DELIM);
-            sb.append(user.getProxyUser());
-        }
-
-        if (token.getScope() != null)
-        {
+        if (token.getScope() != null) {
             sb.append(FIELD_DELIM);
             sb.append(SCOPE_LABEL);
             sb.append(VALUE_DELIM);
@@ -260,8 +237,7 @@ public class DelegationToken implements Serializable
         }
 
         if (token.getDomains() != null) {
-            for (String domain : token.getDomains())
-            {
+            for (String domain : token.getDomains()) {
                 sb.append(FIELD_DELIM);
                 sb.append(DOMAIN_LABEL);
                 sb.append(VALUE_DELIM);
@@ -274,124 +250,82 @@ public class DelegationToken implements Serializable
     }
 
     /**
-     *
-     * @param text
-     * @param requestURI
-     * @return
-     * @throws InvalidDelegationTokenException
+     * @param text       The content of the token to parse.
+     * @param requestURI The Request URI
+     * @return DelegationToken instance, with parsed content.
+     * @throws InvalidDelegationTokenException If the token is not in the expected format.
      */
     public static DelegationToken parse(String text, String requestURI)
-            throws InvalidDelegationTokenException
-    {
+        throws InvalidDelegationTokenException {
         return parse(text, requestURI, null);
     }
 
     /**
      * Builds a DelegationToken from a text string
-     * @param text to parse
+     *
+     * @param text       to parse
      * @param requestURI the request URI
-     * @param sv
+     * @param sv         For validating the scope part of the token.
      * @return corresponding DelegationToken
-     * @throws InvalidDelegationTokenException
+     * @throws InvalidDelegationTokenException If the token is not in the expected format.
      */
     public static DelegationToken parse(String text, String requestURI, ScopeValidator sv)
-            throws InvalidDelegationTokenException
-    {
+        throws InvalidDelegationTokenException {
         String[] fields = text.split(FIELD_DELIM);
-        String userid = null;
         Set<Principal> principalSet = new HashSet<>();
-        String proxyUser = null;
         Date expirytime = null;
         URI scope = null;
         String signature = null;
         List<String> domains = new ArrayList<>();
-        try
-        {
-            for (String field : fields)
-            {
-
+        try {
+            for (String field : fields) {
                 String key = field.substring(0, field.indexOf(VALUE_DELIM));
                 String value = field.substring(field.indexOf(VALUE_DELIM) + 1);
                 log.debug("key = value: " + key + "=" + value);
 
-                if (key.equalsIgnoreCase(IdentityType.USERID.getValue()))
-                {
-                    userid = value;
-                }
-                else if (key.equalsIgnoreCase(PROXY_LABEL))
-                {
-                    proxyUser = value;
-                }
-                else if (key.equalsIgnoreCase(IdentityType.X500.getValue().toLowerCase()))
-                {
-                    principalSet.add(new X500Principal(value));
-                }
-                // Treating CADC principal as a NumericPrincipal
-                // check for both for backward cookie compatibility
-                else if (key.equalsIgnoreCase(IdentityType.NUMERICID.getValue())
-                    || key.equalsIgnoreCase(IdentityType.CADC.getValue()))
-                {
-                    principalSet.add(new NumericPrincipal(UUID.fromString(value)));
-                }
-                else if (key.equalsIgnoreCase(EXPIRY_LABEL))
-                {
+                if (key.equalsIgnoreCase(IDENTITIES_LABEL)) {
+                    principalSet = DelegationToken.decodePrincipals(value);
+                } else if (key.equalsIgnoreCase(EXPIRY_LABEL)) {
                     expirytime = new Date(Long.valueOf(value));
-                }
-                else if (key.equalsIgnoreCase(SCOPE_LABEL))
-                {
+                } else if (key.equalsIgnoreCase(SCOPE_LABEL)) {
                     scope = new URI(value);
-                }
-                else if (key.equalsIgnoreCase(SIGNATURE_LABEL))
-                {
+                } else if (key.equalsIgnoreCase(SIGNATURE_LABEL)) {
                     signature = value;
-                }
-                else if (key.equalsIgnoreCase(DOMAIN_LABEL))
-                {
+                } else if (key.equalsIgnoreCase(DOMAIN_LABEL)) {
                     domains.add(value);
                 }
             }
-
-            // Construct HttpPrincipal
-            if (userid != null && proxyUser != null)
-            {
-                principalSet.add(new HttpPrincipal(userid, proxyUser));
-            } else if (userid != null)
-            {
-                principalSet.add(new HttpPrincipal(userid));
-            }
-            
-        }
-        catch (NumberFormatException ex)
-        {
+        } catch (NumberFormatException ex) {
             throw new InvalidDelegationTokenException("invalid numeric field", ex);
-        }
-        catch (URISyntaxException ex)
-        {
+        } catch (URISyntaxException ex) {
             throw new InvalidDelegationTokenException("invalid scope URI", ex);
         }
 
-        if (signature == null)
+        if (signature == null) {
             throw new InvalidDelegationTokenException("missing signature");
+        }
 
         // validate expiry
-        if (expirytime == null)
+        if (expirytime == null) {
             throw new InvalidDelegationTokenException("missing expirytime");
+        }
         Date now = new Date();
 
-        if (now.getTime() > expirytime.getTime())
+        if (now.getTime() > expirytime.getTime()) {
             throw new InvalidDelegationTokenException("expired");
+        }
 
         // validate scope
-        if (scope != null)
-        {
+        if (scope != null) {
             if (sv == null) // not supplied
+            {
                 sv = getScopeValidator();
+            }
             sv.verifyScope(scope, requestURI);
         }
 
         // validate signature
-        try
-        {
+        try {
             RsaSignatureVerifier su = new RsaSignatureVerifier();
             String signatureSplitter = FIELD_DELIM + DelegationToken.SIGNATURE_LABEL + "=";
             String[] cookieNSignature = text.split(signatureSplitter);
@@ -400,15 +334,12 @@ public class DelegationToken implements Serializable
                 new ByteArrayInputStream(cookieNSignature[0].getBytes()),
                 Base64.decode(signature));
 
-            if (!valid)
-            {
+            if (!valid) {
                 log.error("invalid signature: " + text);
                 throw new InvalidDelegationTokenException("cannot verify signature");
             }
 
-        }
-        catch(Exception ex)
-        {
+        } catch (Exception ex) {
             log.debug("failed to verify DelegationToken signature", ex);
             throw new InvalidDelegationTokenException("cannot verify signature", ex);
         }
@@ -417,11 +348,93 @@ public class DelegationToken implements Serializable
 
     }
 
-    private static ScopeValidator getScopeValidator()
-    {
-        try
-        {
-            String fname = DelegationToken.class.getSimpleName()+".properties";
+    private static Map<String, String> principalKeysToMap(final String principalsQueryString) {
+        final Map<String, String> mappedValues = new HashMap<>();
+        for (final String pair : principalsQueryString.split(FIELD_DELIM)) {
+            final int valueSplitIndex = pair.indexOf(VALUE_DELIM);
+
+            // We can't use the pair.split(VALUE_DELIM) here because the X500 DN contains '='.
+            final String key = pair.substring(0, valueSplitIndex);
+            final String value = pair.substring(valueSplitIndex + 1);
+            if (StringUtil.hasLength(key) && StringUtil.hasLength(value)) {
+                mappedValues.put(key, value);
+            }
+        }
+        return mappedValues;
+    }
+
+    /**
+     * Obtain a char array of the Base64 encoded principals.
+     * @param identityPrincipals        The Set of Principal instances.
+     * @return  A new char array of encoded values, or empty array.  Never null.
+     */
+    static char[] encodePrincipals(final Set<Principal> identityPrincipals) {
+        final StringBuilder principalBuilder = new StringBuilder();
+        // Add all available identity principals to the content
+        for (final Principal principal : identityPrincipals) {
+            final String principalName = principal.getClass().getSimpleName();
+            final IdentityType principalIdentity = IdentityType.principalIdentityMap.get(principalName);
+
+            // User ID has a custom value.
+            if (principalIdentity == IdentityType.USERID) {
+                final HttpPrincipal httpPrincipal = (HttpPrincipal) principal;
+
+                principalBuilder.append(USER_LABEL);
+                principalBuilder.append(VALUE_DELIM);
+                principalBuilder.append(principal.getName());
+
+                if (StringUtil.hasText(httpPrincipal.getProxyUser())) {
+                    principalBuilder.append(FIELD_DELIM);
+                    principalBuilder.append(PROXY_LABEL);
+                    principalBuilder.append(VALUE_DELIM);
+                    principalBuilder.append(httpPrincipal.getProxyUser());
+                }
+            } else if (!principalIdentity.equals(IdentityType.ENTRY_DN)) {
+                // Do not add this for external use, to cookies, etc.
+                principalBuilder.append(principalIdentity.getValue());
+                principalBuilder.append(VALUE_DELIM);
+                principalBuilder.append(principal.getName());
+            }
+
+            principalBuilder.append(FIELD_DELIM);
+        }
+
+        if (principalBuilder.lastIndexOf(FIELD_DELIM) > 0) {
+            principalBuilder.deleteCharAt(principalBuilder.lastIndexOf(FIELD_DELIM));
+        }
+
+        return Base64.encode(principalBuilder.toString().getBytes());
+    }
+
+    private static Set<Principal> decodePrincipals(final String base64EncodedString) {
+        final String decodedPrincipals = new String(Base64.decode(base64EncodedString));
+        final Map<String, String> decodedPrincipalsMap = DelegationToken.principalKeysToMap(decodedPrincipals);
+        final Set<Principal> principals = new HashSet<>();
+
+        if (decodedPrincipalsMap.containsKey(USER_LABEL)) {
+            final String httpUserID = decodedPrincipalsMap.get(USER_LABEL);
+            if (decodedPrincipalsMap.containsKey(PROXY_LABEL)) {
+                principals.add(new HttpPrincipal(httpUserID, decodedPrincipalsMap.get(PROXY_LABEL)));
+            } else {
+                principals.add(new HttpPrincipal(httpUserID));
+            }
+        }
+
+        if (decodedPrincipalsMap.containsKey(IdentityType.NUMERICID.getValue())) {
+            principals.add(new NumericPrincipal(UUID.fromString(
+                decodedPrincipalsMap.get(IdentityType.NUMERICID.getValue()))));
+        }
+
+        if (decodedPrincipalsMap.containsKey(IdentityType.X500.getValue())) {
+            principals.add(new X500Principal(decodedPrincipalsMap.get(IdentityType.X500.getValue())));
+        }
+
+        return principals;
+    }
+
+    private static ScopeValidator getScopeValidator() {
+        try {
+            String fname = DelegationToken.class.getSimpleName() + ".properties";
             String pname = DelegationToken.class.getName() + ".scopeValidator";
             Properties props = new Properties();
             props.load(DelegationToken.class.getClassLoader().getResource(fname).openStream());
@@ -431,12 +444,9 @@ public class DelegationToken implements Serializable
             ScopeValidator ret = (ScopeValidator) c.newInstance();
             log.debug("created: " + ret.getClass().getName());
             return ret;
-        }
-        catch(Exception ignore)
-        {
+        } catch (Exception ignore) {
             log.debug("failed to load custom ScopeValidator", ignore);
         }
-        finally { }
 
         // default
         return new ScopeValidator();
@@ -447,25 +457,20 @@ public class DelegationToken implements Serializable
         return getPrincipalByClass(HttpPrincipal.class);
     }
 
-    public <T extends Principal> T getPrincipalByClass(Class clazz)
-    {
-        for (Principal prin : this.identityPrincipals)
-        {
-            if (prin.getClass() == clazz)
-            {
-                return (T)prin;
+    public <T extends Principal> T getPrincipalByClass(Class clazz) {
+        for (Principal prin : this.identityPrincipals) {
+            if (prin.getClass() == clazz) {
+                return (T) prin;
             }
         }
         return null;
     }
 
-    public Date getExpiryTime()
-    {
+    public Date getExpiryTime() {
         return expiryTime;
     }
 
-    public URI getScope()
-    {
+    public URI getScope() {
         return scope;
     }
 
@@ -476,23 +481,21 @@ public class DelegationToken implements Serializable
 
     // TODO: update this to include principals
     @Override
-    public String toString()
-    {
+    public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("DelegationToken(" + USER_LABEL + "=");
-        if (StringUtil.hasText(getUser().getProxyUser()))
-        {
-            sb.append("," + PROXY_LABEL + "=");
+        sb.append("DelegationToken(").append(USER_LABEL).append("=");
+        if (StringUtil.hasText(getUser().getProxyUser())) {
+            sb.append(",").append(PROXY_LABEL).append("=");
             sb.append(getUser().getProxyUser());
         }
         sb.append(getUser());
-        sb.append("," + SCOPE_LABEL + "=");
+        sb.append(",").append(SCOPE_LABEL).append("=");
         sb.append(getScope());
         sb.append(",startTime=");
         sb.append(getExpiryTime());
 
-        for (String domain: domains) {
-            sb.append(","+ DOMAIN_LABEL + "=" + domain);
+        for (String domain : domains) {
+            sb.append(",").append(DOMAIN_LABEL).append("=").append(domain);
         }
         sb.append(")");
         return sb.toString();
@@ -528,7 +531,4 @@ public class DelegationToken implements Serializable
     public Set<Principal> getIdentityPrincipals() {
         return identityPrincipals;
     }
-
-
-
 }

--- a/cadc-util/src/main/java/ca/nrc/cadc/auth/DelegationToken.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/auth/DelegationToken.java
@@ -1,71 +1,71 @@
 /*
- ************************************************************************
- *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
- **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
- *
- *  (c) 2018.                            (c) 2018.
- *  Government of Canada                 Gouvernement du Canada
- *  National Research Council            Conseil national de recherches
- *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
- *  All rights reserved                  Tous droits réservés
- *
- *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
- *  expressed, implied, or               énoncée, implicite ou légale,
- *  statutory, of any kind with          de quelque nature que ce
- *  respect to the software,             soit, concernant le logiciel,
- *  including without limitation         y compris sans restriction
- *  any warranty of merchantability      toute garantie de valeur
- *  or fitness for a particular          marchande ou de pertinence
- *  purpose. NRC shall not be            pour un usage particulier.
- *  liable in any event for any          Le CNRC ne pourra en aucun cas
- *  damages, whether direct or           être tenu responsable de tout
- *  indirect, special or general,        dommage, direct ou indirect,
- *  consequential or incidental,         particulier ou général,
- *  arising from the use of the          accessoire ou fortuit, résultant
- *  software.  Neither the name          de l'utilisation du logiciel. Ni
- *  of the National Research             le nom du Conseil National de
- *  Council of Canada nor the            Recherches du Canada ni les noms
- *  names of its contributors may        de ses  participants ne peuvent
- *  be used to endorse or promote        être utilisés pour approuver ou
- *  products derived from this           promouvoir les produits dérivés
- *  software without specific prior      de ce logiciel sans autorisation
- *  written permission.                  préalable et particulière
- *                                       par écrit.
- *
- *  This file is part of the             Ce fichier fait partie du projet
- *  OpenCADC project.                    OpenCADC.
- *
- *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
- *  you can redistribute it and/or       vous pouvez le redistribuer ou le
- *  modify it under the terms of         modifier suivant les termes de
- *  the GNU Affero General Public        la “GNU Affero General Public
- *  License as published by the          License” telle que publiée
- *  Free Software Foundation,            par la Free Software Foundation
- *  either version 3 of the              : soit la version 3 de cette
- *  License, or (at your option)         licence, soit (à votre gré)
- *  any later version.                   toute version ultérieure.
- *
- *  OpenCADC is distributed in the       OpenCADC est distribué
- *  hope that it will be useful,         dans l’espoir qu’il vous
- *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
- *  without even the implied             GARANTIE : sans même la garantie
- *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
- *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
- *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
- *  General Public License for           Générale Publique GNU Affero
- *  more details.                        pour plus de détails.
- *
- *  You should have received             Vous devriez avoir reçu une
- *  a copy of the GNU Affero             copie de la Licence Générale
- *  General Public License along         Publique GNU Affero avec
- *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
- *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
- *                                       <http://www.gnu.org/licenses/>.
- *
- *  $Revision: 5 $
- *
- ************************************************************************
- */
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2018.                            (c) 2018.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+*  $Revision: 5 $
+*
+************************************************************************
+*/
 
 package ca.nrc.cadc.auth;
 
@@ -79,21 +79,22 @@ import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Date;
 
+import ca.nrc.cadc.auth.encoding.TokenEncoderDecoder;
+import ca.nrc.cadc.auth.encoding.TokenEncoding;
 import ca.nrc.cadc.util.Base64;
 import ca.nrc.cadc.util.RsaSignatureGenerator;
 import ca.nrc.cadc.util.RsaSignatureVerifier;
 import ca.nrc.cadc.util.StringUtil;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import javax.security.auth.x500.X500Principal;
 
 import org.apache.log4j.Logger;
+
 
 /**
  * Class that captures the information required to perform delegation (i.e.
@@ -116,13 +117,11 @@ public class DelegationToken implements Serializable {
     public static String PROXY_LABEL = "proxyuser";
     public static String SCOPE_LABEL = "scope";
     public static String DOMAIN_LABEL = "domain";
-
-    // Why not simply re-use the IdentityType.USERID.getValue() here rather than a yet another custom label?
     public static String USER_LABEL = "userid";
     public static String EXPIRY_LABEL = "expirytime";
     public static String SIGNATURE_LABEL = "signature";
-    public static String IDENTITIES_LABEL = "identities";
 
+    private static final TokenEncoderDecoder TOKEN_ENCODER_DECODER = new TokenEncoderDecoder();
 
     private Date expiryTime; // expiration time of the delegation (UTC)
     private URI scope; // resources that are the object of the delegation
@@ -194,10 +193,23 @@ public class DelegationToken implements Serializable {
      * @param token the token to format
      *              the returned string
      * @return String with DelegationToken information
-     * @throws IOException         IO problems
-     * @throws InvalidKeyException The provided key is invalid
+     * @throws IOException         Any IO Errors.
+     * @throws InvalidKeyException If the signature cannot be completed.
      */
-    public static String format(DelegationToken token)
+    public static String format(DelegationToken token)  throws InvalidKeyException, IOException {
+        return format(token, TokenEncoding.BASE64);
+    }
+
+    /**
+     * Serializes and signs the object into a string of attribute-value pairs.
+     *
+     * @param token the token to format
+     *              the returned string
+     * @return String with DelegationToken information, with a "scheme" to indicate the encoding type.
+     * @throws IOException         Any IO Errors.
+     * @throws InvalidKeyException If the signature cannot be completed.
+     */
+    public static String format(final DelegationToken token, final TokenEncoding tokenEncoding)
         throws InvalidKeyException, IOException {
         StringBuilder sb = getContent(token);
 
@@ -207,11 +219,15 @@ public class DelegationToken implements Serializable {
         sb.append(FIELD_DELIM);
         sb.append(SIGNATURE_LABEL);
         sb.append(VALUE_DELIM);
-        RsaSignatureGenerator su = new RsaSignatureGenerator();
-        byte[] sig = su.sign(new ByteArrayInputStream(toSign.getBytes()));
+
+        // Signature is always Base64 encoded.  This is necessary because the value of the Signature alone cannot be
+        // easily transported.
+        final RsaSignatureGenerator su = new RsaSignatureGenerator();
+        final byte[] sig = su.sign(new ByteArrayInputStream(toSign.getBytes()));
         sb.append(new String(Base64.encode(sig)));
 
-        return sb.toString();
+        return tokenEncoding.name().toLowerCase() + ":"
+            + new String(TOKEN_ENCODER_DECODER.encode(sb.toString().getBytes(), tokenEncoding));
     }
 
     // the formatted content without the signature
@@ -221,12 +237,28 @@ public class DelegationToken implements Serializable {
         sb.append(EXPIRY_LABEL).append(VALUE_DELIM);
         sb.append(token.getExpiryTime().getTime());
 
-        final Set<Principal> identityPrincipals = token.identityPrincipals;
+        // Add all available identity principals to the content
+        for (Principal prin : token.identityPrincipals) {
+            String principalName = prin.getClass().getSimpleName();
 
-        if (!identityPrincipals.isEmpty()) {
+            IdentityType principalIdentity = IdentityType.principalIdentityMap.get(principalName);
+            if (principalIdentity.equals(IdentityType.ENTRY_DN)) {
+                // Do not add this for external use, to cookies, etc.
+                continue;
+            }
+
             sb.append(FIELD_DELIM);
-            sb.append(IDENTITIES_LABEL).append(VALUE_DELIM);
-            sb.append(DelegationToken.encodePrincipals(identityPrincipals));
+            sb.append(principalIdentity.getValue());
+            sb.append(VALUE_DELIM);
+            sb.append(prin.getName());
+        }
+
+        HttpPrincipal user = token.getUser();
+        if (StringUtil.hasText(user.getProxyUser())) {
+            sb.append(FIELD_DELIM);
+            sb.append(PROXY_LABEL);
+            sb.append(VALUE_DELIM);
+            sb.append(user.getProxyUser());
         }
 
         if (token.getScope() != null) {
@@ -250,10 +282,12 @@ public class DelegationToken implements Serializable {
     }
 
     /**
-     * @param text       The content of the token to parse.
-     * @param requestURI The Request URI
-     * @return DelegationToken instance, with parsed content.
-     * @throws InvalidDelegationTokenException If the token is not in the expected format.
+     * Parse the given text into a DelegationToken object.
+     *
+     * @param text       The token string.
+     * @param requestURI The HTTP Request URI
+     * @return DelegationToken instance.  Never null.
+     * @throws InvalidDelegationTokenException If the given token cannot be parsed.
      */
     public static DelegationToken parse(String text, String requestURI)
         throws InvalidDelegationTokenException {
@@ -263,28 +297,68 @@ public class DelegationToken implements Serializable {
     /**
      * Builds a DelegationToken from a text string
      *
-     * @param text       to parse
-     * @param requestURI the request URI
-     * @param sv         For validating the scope part of the token.
+     * @param text       Token to parse
+     * @param requestURI The HTTP Request URI
+     * @param sv         ScopeValidator instance.
      * @return corresponding DelegationToken
-     * @throws InvalidDelegationTokenException If the token is not in the expected format.
+     * @throws InvalidDelegationTokenException If the given token cannot be parsed.
      */
     public static DelegationToken parse(String text, String requestURI, ScopeValidator sv)
         throws InvalidDelegationTokenException {
-        String[] fields = text.split(FIELD_DELIM);
+
+        if (text.startsWith(DelegationToken.EXPIRY_LABEL)) {
+            final String[] fields = text.split(FIELD_DELIM);
+            return parse(fields, text, requestURI, sv);
+        } else {
+            return parseEncoded(URI.create(text), requestURI, sv);
+        }
+    }
+
+    private static DelegationToken parseEncoded(final URI encodedURI, final String requestURI,
+                                                final ScopeValidator scopeValidator)
+        throws InvalidDelegationTokenException {
+
+        if (!StringUtil.hasLength(encodedURI.getScheme())) {
+            throw new InvalidDelegationTokenException("Wrong format for encoded token.");
+        } else {
+            final TokenEncoding tokenEncoding = TokenEncoding.valueOf(encodedURI.getScheme().toUpperCase());
+            final byte[] decodedBytes = TOKEN_ENCODER_DECODER.decode(encodedURI.getSchemeSpecificPart(), tokenEncoding);
+            final String decodedString = new String(decodedBytes);
+
+            return parse(decodedString.split(FIELD_DELIM), decodedString, requestURI, scopeValidator);
+        }
+    }
+
+    private static DelegationToken parse(String[] fields, String cookieText, String requestURI, ScopeValidator sv)
+        throws InvalidDelegationTokenException {
+        String userid = null;
         Set<Principal> principalSet = new HashSet<>();
+        String proxyUser = null;
         Date expirytime = null;
         URI scope = null;
         String signature = null;
         List<String> domains = new ArrayList<>();
         try {
-            for (String field : fields) {
+            for (final String field : fields) {
+
+                log.info("Field: " + field);
+
                 String key = field.substring(0, field.indexOf(VALUE_DELIM));
                 String value = field.substring(field.indexOf(VALUE_DELIM) + 1);
                 log.debug("key = value: " + key + "=" + value);
 
-                if (key.equalsIgnoreCase(IDENTITIES_LABEL)) {
-                    principalSet = DelegationToken.decodePrincipals(value);
+                if (key.equalsIgnoreCase(IdentityType.USERID.getValue())) {
+                    userid = value;
+                } else if (key.equalsIgnoreCase(PROXY_LABEL)) {
+                    proxyUser = value;
+                } else if (key.equalsIgnoreCase(IdentityType.X500.getValue().toLowerCase())) {
+                    principalSet.add(new X500Principal(value));
+                }
+                // Treating CADC principal as a NumericPrincipal
+                // check for both for backward cookie compatibility
+                else if (key.equalsIgnoreCase(IdentityType.NUMERICID.getValue())
+                    || key.equalsIgnoreCase(IdentityType.CADC.getValue())) {
+                    principalSet.add(new NumericPrincipal(UUID.fromString(value)));
                 } else if (key.equalsIgnoreCase(EXPIRY_LABEL)) {
                     expirytime = new Date(Long.valueOf(value));
                 } else if (key.equalsIgnoreCase(SCOPE_LABEL)) {
@@ -295,6 +369,14 @@ public class DelegationToken implements Serializable {
                     domains.add(value);
                 }
             }
+
+            // Construct HttpPrincipal
+            if (userid != null && proxyUser != null) {
+                principalSet.add(new HttpPrincipal(userid, proxyUser));
+            } else if (userid != null) {
+                principalSet.add(new HttpPrincipal(userid));
+            }
+
         } catch (NumberFormatException ex) {
             throw new InvalidDelegationTokenException("invalid numeric field", ex);
         } catch (URISyntaxException ex) {
@@ -317,25 +399,30 @@ public class DelegationToken implements Serializable {
 
         // validate scope
         if (scope != null) {
-            if (sv == null) // not supplied
-            {
+            if (sv == null) { // not supplied
                 sv = getScopeValidator();
             }
             sv.verifyScope(scope, requestURI);
         }
 
+        validateSignature(signature, cookieText);
+
+        return new DelegationToken(principalSet, scope, expirytime, domains);
+    }
+
+    private static void validateSignature(final String signatureString, final String text) throws
+        InvalidDelegationTokenException {
         // validate signature
         try {
+            final byte[] signature = Base64.decode(signatureString);
             RsaSignatureVerifier su = new RsaSignatureVerifier();
             String signatureSplitter = FIELD_DELIM + DelegationToken.SIGNATURE_LABEL + "=";
             String[] cookieNSignature = text.split(signatureSplitter);
             log.debug("string to be verified" + cookieNSignature[0]);
-            boolean valid = su.verify(
-                new ByteArrayInputStream(cookieNSignature[0].getBytes()),
-                Base64.decode(signature));
+            boolean valid = su.verify(new ByteArrayInputStream(cookieNSignature[0].getBytes()), signature);
 
             if (!valid) {
-                log.error("invalid signature: " + text);
+                log.error("invalid signature: " + new String(signature));
                 throw new InvalidDelegationTokenException("cannot verify signature");
             }
 
@@ -343,95 +430,6 @@ public class DelegationToken implements Serializable {
             log.debug("failed to verify DelegationToken signature", ex);
             throw new InvalidDelegationTokenException("cannot verify signature", ex);
         }
-
-        return new DelegationToken(principalSet, scope, expirytime, domains);
-
-    }
-
-    private static Map<String, String> principalKeysToMap(final String principalsQueryString) {
-        final Map<String, String> mappedValues = new HashMap<>();
-        for (final String pair : principalsQueryString.split(FIELD_DELIM)) {
-            final int valueSplitIndex = pair.indexOf(VALUE_DELIM);
-
-            // We can't use the pair.split(VALUE_DELIM) here because the X500 DN contains '='.
-            final String key = pair.substring(0, valueSplitIndex);
-            final String value = pair.substring(valueSplitIndex + 1);
-            if (StringUtil.hasLength(key) && StringUtil.hasLength(value)) {
-                mappedValues.put(key, value);
-            }
-        }
-        return mappedValues;
-    }
-
-    /**
-     * Obtain a char array of the Base64 encoded principals.
-     * @param identityPrincipals        The Set of Principal instances.
-     * @return  A new char array of encoded values, or empty array.  Never null.
-     */
-    static char[] encodePrincipals(final Set<Principal> identityPrincipals) {
-        final StringBuilder principalBuilder = new StringBuilder();
-        // Add all available identity principals to the content
-        for (final Principal principal : identityPrincipals) {
-            final String principalName = principal.getClass().getSimpleName();
-            final IdentityType principalIdentity = IdentityType.principalIdentityMap.get(principalName);
-
-            // User ID has a custom value.
-            if (principalIdentity == IdentityType.USERID) {
-                final HttpPrincipal httpPrincipal = (HttpPrincipal) principal;
-
-                principalBuilder.append(USER_LABEL);
-                principalBuilder.append(VALUE_DELIM);
-                principalBuilder.append(principal.getName());
-
-                if (StringUtil.hasText(httpPrincipal.getProxyUser())) {
-                    principalBuilder.append(FIELD_DELIM);
-                    principalBuilder.append(PROXY_LABEL);
-                    principalBuilder.append(VALUE_DELIM);
-                    principalBuilder.append(httpPrincipal.getProxyUser());
-                }
-
-                principalBuilder.append(FIELD_DELIM);
-            } else if (!principalIdentity.equals(IdentityType.ENTRY_DN)) {
-                // Do not add this for external use, to cookies, etc.
-                principalBuilder.append(principalIdentity.getValue());
-                principalBuilder.append(VALUE_DELIM);
-                principalBuilder.append(principal.getName());
-
-                principalBuilder.append(FIELD_DELIM);
-            }
-        }
-
-        if (principalBuilder.lastIndexOf(FIELD_DELIM) > 0) {
-            principalBuilder.deleteCharAt(principalBuilder.lastIndexOf(FIELD_DELIM));
-        }
-
-        return Base64.encode(principalBuilder.toString().getBytes());
-    }
-
-    private static Set<Principal> decodePrincipals(final String base64EncodedString) {
-        final String decodedPrincipals = new String(Base64.decode(base64EncodedString));
-        final Map<String, String> decodedPrincipalsMap = DelegationToken.principalKeysToMap(decodedPrincipals);
-        final Set<Principal> principals = new HashSet<>();
-
-        if (decodedPrincipalsMap.containsKey(USER_LABEL)) {
-            final String httpUserID = decodedPrincipalsMap.get(USER_LABEL);
-            if (decodedPrincipalsMap.containsKey(PROXY_LABEL)) {
-                principals.add(new HttpPrincipal(httpUserID, decodedPrincipalsMap.get(PROXY_LABEL)));
-            } else {
-                principals.add(new HttpPrincipal(httpUserID));
-            }
-        }
-
-        if (decodedPrincipalsMap.containsKey(IdentityType.NUMERICID.getValue())) {
-            principals.add(new NumericPrincipal(UUID.fromString(
-                decodedPrincipalsMap.get(IdentityType.NUMERICID.getValue()))));
-        }
-
-        if (decodedPrincipalsMap.containsKey(IdentityType.X500.getValue())) {
-            principals.add(new X500Principal(decodedPrincipalsMap.get(IdentityType.X500.getValue())));
-        }
-
-        return principals;
     }
 
     private static ScopeValidator getScopeValidator() {

--- a/cadc-util/src/main/java/ca/nrc/cadc/auth/DelegationToken.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/auth/DelegationToken.java
@@ -389,14 +389,16 @@ public class DelegationToken implements Serializable {
                     principalBuilder.append(VALUE_DELIM);
                     principalBuilder.append(httpPrincipal.getProxyUser());
                 }
+
+                principalBuilder.append(FIELD_DELIM);
             } else if (!principalIdentity.equals(IdentityType.ENTRY_DN)) {
                 // Do not add this for external use, to cookies, etc.
                 principalBuilder.append(principalIdentity.getValue());
                 principalBuilder.append(VALUE_DELIM);
                 principalBuilder.append(principal.getName());
-            }
 
-            principalBuilder.append(FIELD_DELIM);
+                principalBuilder.append(FIELD_DELIM);
+            }
         }
 
         if (principalBuilder.lastIndexOf(FIELD_DELIM) > 0) {

--- a/cadc-util/src/main/java/ca/nrc/cadc/auth/encoding/TokenEncoderDecoder.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/auth/encoding/TokenEncoderDecoder.java
@@ -1,0 +1,103 @@
+
+/*
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2018.                            (c) 2018.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *
+ ************************************************************************
+ */
+
+package ca.nrc.cadc.auth.encoding;
+
+import ca.nrc.cadc.auth.InvalidDelegationTokenException;
+import ca.nrc.cadc.util.Base64;
+
+import java.io.UnsupportedEncodingException;
+
+
+public class TokenEncoderDecoder {
+    public byte[] decode(final String value, final TokenEncoding tokenEncoding)
+        throws InvalidDelegationTokenException {
+        switch (tokenEncoding) {
+            case BASE64: {
+                return Base64.decode(value);
+            }
+
+            default: {
+                throw new InvalidDelegationTokenException(String.format("Unsupported encoding '%s'", tokenEncoding));
+            }
+        }
+    }
+
+    public char[] encode(final byte[] bytes, final TokenEncoding tokenEncoding) throws UnsupportedEncodingException {
+        switch (tokenEncoding) {
+            case BASE64: {
+                return Base64.encode(bytes);
+            }
+
+            default: {
+                throw new UnsupportedEncodingException(String.format("Unsupported encoding '%s'", tokenEncoding));
+            }
+        }
+    }
+}

--- a/cadc-util/src/main/java/ca/nrc/cadc/auth/encoding/TokenEncoding.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/auth/encoding/TokenEncoding.java
@@ -1,0 +1,76 @@
+/*
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2018.                            (c) 2018.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *
+ ************************************************************************
+ */
+
+package ca.nrc.cadc.auth.encoding;
+
+/**
+ * Here to support future encodings.
+ */
+public enum TokenEncoding {
+    BASE64
+}

--- a/cadc-util/src/test/java/ca/nrc/cadc/auth/DelegationTokenTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/auth/DelegationTokenTest.java
@@ -1,71 +1,71 @@
 /*
-************************************************************************
-*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
-**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
-*
-*  (c) 2018.                            (c) 2018.
-*  Government of Canada                 Gouvernement du Canada
-*  National Research Council            Conseil national de recherches
-*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-*  All rights reserved                  Tous droits réservés
-*
-*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
-*  expressed, implied, or               énoncée, implicite ou légale,
-*  statutory, of any kind with          de quelque nature que ce
-*  respect to the software,             soit, concernant le logiciel,
-*  including without limitation         y compris sans restriction
-*  any warranty of merchantability      toute garantie de valeur
-*  or fitness for a particular          marchande ou de pertinence
-*  purpose. NRC shall not be            pour un usage particulier.
-*  liable in any event for any          Le CNRC ne pourra en aucun cas
-*  damages, whether direct or           être tenu responsable de tout
-*  indirect, special or general,        dommage, direct ou indirect,
-*  consequential or incidental,         particulier ou général,
-*  arising from the use of the          accessoire ou fortuit, résultant
-*  software.  Neither the name          de l'utilisation du logiciel. Ni
-*  of the National Research             le nom du Conseil National de
-*  Council of Canada nor the            Recherches du Canada ni les noms
-*  names of its contributors may        de ses  participants ne peuvent
-*  be used to endorse or promote        être utilisés pour approuver ou
-*  products derived from this           promouvoir les produits dérivés
-*  software without specific prior      de ce logiciel sans autorisation
-*  written permission.                  préalable et particulière
-*                                       par écrit.
-*
-*  This file is part of the             Ce fichier fait partie du projet
-*  OpenCADC project.                    OpenCADC.
-*
-*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
-*  you can redistribute it and/or       vous pouvez le redistribuer ou le
-*  modify it under the terms of         modifier suivant les termes de
-*  the GNU Affero General Public        la “GNU Affero General Public
-*  License as published by the          License” telle que publiée
-*  Free Software Foundation,            par la Free Software Foundation
-*  either version 3 of the              : soit la version 3 de cette
-*  License, or (at your option)         licence, soit (à votre gré)
-*  any later version.                   toute version ultérieure.
-*
-*  OpenCADC is distributed in the       OpenCADC est distribué
-*  hope that it will be useful,         dans l’espoir qu’il vous
-*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
-*  without even the implied             GARANTIE : sans même la garantie
-*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
-*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
-*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
-*  General Public License for           Générale Publique GNU Affero
-*  more details.                        pour plus de détails.
-*
-*  You should have received             Vous devriez avoir reçu une
-*  a copy of the GNU Affero             copie de la Licence Générale
-*  General Public License along         Publique GNU Affero avec
-*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
-*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
-*                                       <http://www.gnu.org/licenses/>.
-*
-*  $Revision: 5 $
-*
-************************************************************************
-*/
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2018.                            (c) 2018.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  $Revision: 5 $
+ *
+ ************************************************************************
+ */
 
 package ca.nrc.cadc.auth;
 
@@ -73,11 +73,13 @@ import ca.nrc.cadc.util.FileUtil;
 import ca.nrc.cadc.util.Log4jInit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.net.URI;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
@@ -87,46 +89,47 @@ import java.util.TimeZone;
 
 import java.util.UUID;
 import javax.security.auth.x500.X500Principal;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import ca.nrc.cadc.util.RsaSignatureGenerator;
+
 import java.io.File;
 import java.io.FileWriter;
+
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 
-public class DelegationTokenTest
-{
+public class DelegationTokenTest {
     private static final Logger log = Logger.getLogger(DelegationTokenTest.class);
-    
-    static
-    {
+
+    private static final char[] ILLEGAL_COOKIE_CHARACTERS = new char[] {',', ';', '\\', '"'};
+
+    static {
         Log4jInit.setLevel("ca.nrc.cadc.auth", Level.INFO);
         Log4jInit.setLevel("ca.nrc.cadc.util", Level.INFO);
     }
-    
-    public static class TestScopeValidator extends DelegationToken.ScopeValidator
-    {
+
+    public static class TestScopeValidator extends DelegationToken.ScopeValidator {
 
         @Override
-        public void verifyScope(URI scope, String requestURI) 
-            throws InvalidDelegationTokenException 
-        {
-            if ("foo:bar".equals(scope.toASCIIString()) )
+        public void verifyScope(URI scope, String requestURI)
+            throws InvalidDelegationTokenException {
+            if ("foo:bar".equals(scope.toASCIIString())) {
                 return; // OK
+            }
             super.verifyScope(scope, requestURI); // test default behaviour indirectly
         }
-        
+
     }
 
     File pubFile, privFile;
-    
+
     @Before
-    public void initKeys() throws Exception
-    {
+    public void initKeys() throws Exception {
         File config = FileUtil.getFileFromResource("DelegationToken.properties", DelegationTokenTest.class);
         File keysDir = config.getParentFile();
         //String keysDir = RSASignatureGeneratorValidatorTest.getCompleteKeysDirectoryName();
@@ -134,17 +137,15 @@ public class DelegationTokenTest
         privFile = new File(keysDir, RsaSignatureGenerator.PRIV_KEY_FILE_NAME);
         pubFile = new File(keysDir, RsaSignatureGenerator.PUB_KEY_FILE_NAME);
     }
-    
+
     @After
-    public void cleanupKeys() throws Exception
-    {
+    public void cleanupKeys() {
         pubFile.delete();
         privFile.delete();
     }
-    
+
     @Test
-    public void matches() throws Exception
-    {
+    public void matches() throws Exception {
         // configure the test scope validator
         File config = FileUtil.getFileFromResource("DelegationToken.properties", DelegationTokenTest.class);
         FileWriter w = new FileWriter(config);
@@ -167,23 +168,23 @@ public class DelegationTokenTest
         Calendar expiry = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
         expiry.add(Calendar.HOUR, duration);
         DelegationToken expToken = new DelegationToken(userid, scope, expiry.getTime(), domainList);
-        
+
         String token = DelegationToken.format(expToken);
         log.debug("valid token: " + token);
         DelegationToken actToken = DelegationToken.parse(token, null);
-        
+
         assertEquals("User id not the same", expToken.getUser(),
-                actToken.getUser());
+                     actToken.getUser());
         assertEquals("Expiry time not the same", expToken.getExpiryTime(),
-                actToken.getExpiryTime());
+                     actToken.getExpiryTime());
         assertEquals("Scope not the same", expToken.getScope(),
-                actToken.getScope());
+                     actToken.getScope());
         assertEquals("Domain list size not the same", domainList.size(), expToken.getDomains().size());
-        for (String domain: expToken.getDomains()) {
+        for (String domain : expToken.getDomains()) {
             Assert.assertTrue("Domain list content not the same", domainList.contains(domain));
         }
-        
-        
+
+
         // round trip test without signature and principal with proxy user
         userid = new HttpPrincipal("someuser", "someproxyuser");
         scope = new URI("foo:bar");
@@ -195,13 +196,13 @@ public class DelegationTokenTest
         token = DelegationToken.format(expToken);
         log.debug("valid token: " + token);
         actToken = DelegationToken.parse(token, null);
-        
+
         assertEquals("User id not the same", expToken.getUser(),
-                actToken.getUser());
+                     actToken.getUser());
         assertEquals("Expiry time not the same", expToken.getExpiryTime(),
-                actToken.getExpiryTime());
+                     actToken.getExpiryTime());
         assertEquals("Scope not the same", expToken.getScope(),
-                actToken.getScope());
+                     actToken.getScope());
 
         // round trip test without signature and principal with proxy user
         Set<Principal> testPrincipals = new HashSet<>();
@@ -223,74 +224,87 @@ public class DelegationTokenTest
         actToken = DelegationToken.parse(token, null);
 
         assertEquals("User id not the same", expToken.getUser(),
-            actToken.getUser());
+                     actToken.getUser());
         assertEquals("Expiry time not the same", expToken.getExpiryTime(),
-            actToken.getExpiryTime());
+                     actToken.getExpiryTime());
         assertEquals("Scope not the same", expToken.getScope(),
-            actToken.getScope());
+                     actToken.getScope());
         assertEquals("x509 principal not the same", expToken.getPrincipalByClass(X500Principal.class),
-            actToken.getPrincipalByClass(X500Principal.class));
+                     actToken.getPrincipalByClass(X500Principal.class));
         assertEquals("Numeric (CADC) principal not the same", expToken.getPrincipalByClass(NumericPrincipal.class),
-            actToken.getPrincipalByClass(NumericPrincipal.class));
+                     actToken.getPrincipalByClass(NumericPrincipal.class));
 
-        
+
         // invalid scope
-        try
-        {
+        try {
             DelegationToken wrongScope = new DelegationToken(userid, new URI("bar:baz"), expiry.getTime(), null);
             DelegationToken.parse(DelegationToken.format(wrongScope), null);
             fail("Exception expected");
-        }
-        catch(InvalidDelegationTokenException expected) 
-        {
+        } catch (InvalidDelegationTokenException expected) {
             log.debug("caught expected exception: " + expected);
         }
-        
+
         Calendar expiredDate = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
         expiredDate.add(Calendar.DATE, -1);
         // parse expired token
-        try
-        {
+        try {
             expToken = new DelegationToken(userid, scope, expiredDate.getTime(), null);
             DelegationToken.parse(DelegationToken.format(expToken), null);
             fail("Exception expected");
-        }
-        catch(InvalidDelegationTokenException expected) 
-        {
+        } catch (InvalidDelegationTokenException expected) {
             log.debug("caught expected exception: " + expected);
         }
-        
+
         //invalidate signature field
-        try
-        {
+        try {
             expToken = new DelegationToken(userid, scope, expiry.getTime(), null);
-            
+
             token = DelegationToken.format(expToken);
             CharSequence subSequence = token.subSequence(10, token.length());
             DelegationToken.parse(subSequence.toString(), null);
             fail("Exception expected");
-        }
-        catch(InvalidDelegationTokenException expected) 
-        {
+        } catch (InvalidDelegationTokenException expected) {
             log.debug("caught expected exception: " + expected);
         }
 
         // tamper with one character in the signature
-        try
-        {
+        try {
             expToken = new DelegationToken(userid, scope, expiry.getTime(), null);
-            
+
             token = DelegationToken.format(expToken);
             char toReplace = token.charAt(token.indexOf("signature") + 10);
             token = token.substring(0, token.length() - 1);
-                token = token + "A";
+            token = token + "A";
 
             DelegationToken.parse(token, null);
             fail("Exception expected");
-        }
-        catch(InvalidDelegationTokenException expected) 
-        {
+        } catch (InvalidDelegationTokenException expected) {
             log.debug("caught expected exception: " + expected);
+        }
+    }
+
+    @Test
+    public void validCookieValue() throws Exception {
+        final Principal httpPrincipal = new HttpPrincipal("some;user", "someproxyuser");
+        final Principal x509 = new X500Principal("CN=JBP,OU=nrc-cnrc.gc.ca,O=grid,C=CA");
+        final Set<Principal> principals = new HashSet<>();
+
+        principals.add(httpPrincipal);
+        principals.add(x509);
+
+        final URI scope = new URI("foo:bar");
+        final int duration = 10; // h
+        final Calendar expiry = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        expiry.add(Calendar.HOUR, duration);
+        final DelegationToken delegationToken = new DelegationToken(principals, scope, expiry.getTime(), null);
+
+        final String tokenValue = DelegationToken.format(delegationToken);
+
+        for (final char c : ILLEGAL_COOKIE_CHARACTERS) {
+            Assert.assertFalse(String.format("Token %s invalid characters (%s).",
+                                             tokenValue,
+                                             Arrays.toString(ILLEGAL_COOKIE_CHARACTERS)),
+                               tokenValue.contains(Character.toString(c)));
         }
     }
 }

--- a/cadc-util/src/test/java/ca/nrc/cadc/auth/DelegationTokenTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/auth/DelegationTokenTest.java
@@ -1,71 +1,71 @@
 /*
- ************************************************************************
- *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
- **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
- *
- *  (c) 2018.                            (c) 2018.
- *  Government of Canada                 Gouvernement du Canada
- *  National Research Council            Conseil national de recherches
- *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
- *  All rights reserved                  Tous droits réservés
- *
- *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
- *  expressed, implied, or               énoncée, implicite ou légale,
- *  statutory, of any kind with          de quelque nature que ce
- *  respect to the software,             soit, concernant le logiciel,
- *  including without limitation         y compris sans restriction
- *  any warranty of merchantability      toute garantie de valeur
- *  or fitness for a particular          marchande ou de pertinence
- *  purpose. NRC shall not be            pour un usage particulier.
- *  liable in any event for any          Le CNRC ne pourra en aucun cas
- *  damages, whether direct or           être tenu responsable de tout
- *  indirect, special or general,        dommage, direct ou indirect,
- *  consequential or incidental,         particulier ou général,
- *  arising from the use of the          accessoire ou fortuit, résultant
- *  software.  Neither the name          de l'utilisation du logiciel. Ni
- *  of the National Research             le nom du Conseil National de
- *  Council of Canada nor the            Recherches du Canada ni les noms
- *  names of its contributors may        de ses  participants ne peuvent
- *  be used to endorse or promote        être utilisés pour approuver ou
- *  products derived from this           promouvoir les produits dérivés
- *  software without specific prior      de ce logiciel sans autorisation
- *  written permission.                  préalable et particulière
- *                                       par écrit.
- *
- *  This file is part of the             Ce fichier fait partie du projet
- *  OpenCADC project.                    OpenCADC.
- *
- *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
- *  you can redistribute it and/or       vous pouvez le redistribuer ou le
- *  modify it under the terms of         modifier suivant les termes de
- *  the GNU Affero General Public        la “GNU Affero General Public
- *  License as published by the          License” telle que publiée
- *  Free Software Foundation,            par la Free Software Foundation
- *  either version 3 of the              : soit la version 3 de cette
- *  License, or (at your option)         licence, soit (à votre gré)
- *  any later version.                   toute version ultérieure.
- *
- *  OpenCADC is distributed in the       OpenCADC est distribué
- *  hope that it will be useful,         dans l’espoir qu’il vous
- *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
- *  without even the implied             GARANTIE : sans même la garantie
- *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
- *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
- *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
- *  General Public License for           Générale Publique GNU Affero
- *  more details.                        pour plus de détails.
- *
- *  You should have received             Vous devriez avoir reçu une
- *  a copy of the GNU Affero             copie de la Licence Générale
- *  General Public License along         Publique GNU Affero avec
- *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
- *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
- *                                       <http://www.gnu.org/licenses/>.
- *
- *  $Revision: 5 $
- *
- ************************************************************************
- */
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2018.                            (c) 2018.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+*  $Revision: 5 $
+*
+************************************************************************
+*/
 
 package ca.nrc.cadc.auth;
 

--- a/cadc-util/src/test/java/ca/nrc/cadc/auth/DelegationTokenTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/auth/DelegationTokenTest.java
@@ -1,81 +1,80 @@
 /*
-************************************************************************
-*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
-**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
-*
-*  (c) 2018.                            (c) 2018.
-*  Government of Canada                 Gouvernement du Canada
-*  National Research Council            Conseil national de recherches
-*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-*  All rights reserved                  Tous droits réservés
-*
-*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
-*  expressed, implied, or               énoncée, implicite ou légale,
-*  statutory, of any kind with          de quelque nature que ce
-*  respect to the software,             soit, concernant le logiciel,
-*  including without limitation         y compris sans restriction
-*  any warranty of merchantability      toute garantie de valeur
-*  or fitness for a particular          marchande ou de pertinence
-*  purpose. NRC shall not be            pour un usage particulier.
-*  liable in any event for any          Le CNRC ne pourra en aucun cas
-*  damages, whether direct or           être tenu responsable de tout
-*  indirect, special or general,        dommage, direct ou indirect,
-*  consequential or incidental,         particulier ou général,
-*  arising from the use of the          accessoire ou fortuit, résultant
-*  software.  Neither the name          de l'utilisation du logiciel. Ni
-*  of the National Research             le nom du Conseil National de
-*  Council of Canada nor the            Recherches du Canada ni les noms
-*  names of its contributors may        de ses  participants ne peuvent
-*  be used to endorse or promote        être utilisés pour approuver ou
-*  products derived from this           promouvoir les produits dérivés
-*  software without specific prior      de ce logiciel sans autorisation
-*  written permission.                  préalable et particulière
-*                                       par écrit.
-*
-*  This file is part of the             Ce fichier fait partie du projet
-*  OpenCADC project.                    OpenCADC.
-*
-*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
-*  you can redistribute it and/or       vous pouvez le redistribuer ou le
-*  modify it under the terms of         modifier suivant les termes de
-*  the GNU Affero General Public        la “GNU Affero General Public
-*  License as published by the          License” telle que publiée
-*  Free Software Foundation,            par la Free Software Foundation
-*  either version 3 of the              : soit la version 3 de cette
-*  License, or (at your option)         licence, soit (à votre gré)
-*  any later version.                   toute version ultérieure.
-*
-*  OpenCADC is distributed in the       OpenCADC est distribué
-*  hope that it will be useful,         dans l’espoir qu’il vous
-*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
-*  without even the implied             GARANTIE : sans même la garantie
-*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
-*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
-*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
-*  General Public License for           Générale Publique GNU Affero
-*  more details.                        pour plus de détails.
-*
-*  You should have received             Vous devriez avoir reçu une
-*  a copy of the GNU Affero             copie de la Licence Générale
-*  General Public License along         Publique GNU Affero avec
-*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
-*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
-*                                       <http://www.gnu.org/licenses/>.
-*
-*  $Revision: 5 $
-*
-************************************************************************
-*/
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2018.                            (c) 2018.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  $Revision: 5 $
+ *
+ ************************************************************************
+ */
 
 package ca.nrc.cadc.auth;
 
+import ca.nrc.cadc.util.Base64;
 import ca.nrc.cadc.util.FileUtil;
 import ca.nrc.cadc.util.Log4jInit;
+import ca.nrc.cadc.util.RsaSignatureGenerator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -86,22 +85,22 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
-
 import java.util.UUID;
+
 import javax.security.auth.x500.X500Principal;
-
-import org.junit.Assert;
-import org.junit.Test;
-
-import ca.nrc.cadc.util.RsaSignatureGenerator;
 
 import java.io.File;
 import java.io.FileWriter;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
 import org.junit.After;
 import org.junit.Before;
+
 
 public class DelegationTokenTest {
     private static final Logger log = Logger.getLogger(DelegationTokenTest.class);
@@ -132,7 +131,6 @@ public class DelegationTokenTest {
     public void initKeys() throws Exception {
         File config = FileUtil.getFileFromResource("DelegationToken.properties", DelegationTokenTest.class);
         File keysDir = config.getParentFile();
-        //String keysDir = RSASignatureGeneratorValidatorTest.getCompleteKeysDirectoryName();
         RsaSignatureGenerator.genKeyPair(keysDir);
         privFile = new File(keysDir, RsaSignatureGenerator.PRIV_KEY_FILE_NAME);
         pubFile = new File(keysDir, RsaSignatureGenerator.PUB_KEY_FILE_NAME);
@@ -142,6 +140,68 @@ public class DelegationTokenTest {
     public void cleanupKeys() {
         pubFile.delete();
         privFile.delete();
+    }
+
+    @Test
+    public void matchDecode() throws Exception {
+        // configure the test scope validator
+        final File config = FileUtil.getFileFromResource("DelegationToken.properties", DelegationTokenTest.class);
+        final FileWriter w = new FileWriter(config);
+        w.write(DelegationToken.class.getName() + ".scopeValidator = " + TestScopeValidator.class.getName());
+        w.write("\n");
+        w.flush();
+        w.close();
+
+        // round trip test with signature
+
+        final List<String> domainList = new ArrayList<>();
+        domainList.add("www.canfar.phys.uvic.ca");
+        domainList.add("www.cadc.hia.nrc.gc.ca");
+        domainList.add("www.ccda.iha.cnrc.gc.ca");
+        domainList.add("www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca");
+
+        final HttpPrincipal httpPrincipal = new HttpPrincipal("someuser");
+        final URI scope = new URI("foo:bar");
+        final int durationHours = 10; // h
+        Calendar expiry = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        expiry.add(Calendar.HOUR, durationHours);
+
+        StringBuilder tokenValue = new StringBuilder();
+
+        tokenValue.append(DelegationToken.EXPIRY_LABEL);
+        tokenValue.append("=");
+        tokenValue.append(expiry.getTime().getTime());
+        tokenValue.append(DelegationToken.FIELD_DELIM);
+        tokenValue.append(IdentityType.USERID.getValue());
+        tokenValue.append("=");
+        tokenValue.append(httpPrincipal.getName());
+        tokenValue.append(DelegationToken.FIELD_DELIM);
+        tokenValue.append("scope=");
+        tokenValue.append(scope.toString());
+
+        for (final String domain : domainList) {
+            tokenValue.append(DelegationToken.FIELD_DELIM).append("domain=").append(domain);
+        }
+
+        final RsaSignatureGenerator su = new RsaSignatureGenerator();
+        final byte[] sig = su.sign(new ByteArrayInputStream(tokenValue.toString().getBytes()));
+        tokenValue.append(DelegationToken.FIELD_DELIM);
+        tokenValue.append(DelegationToken.SIGNATURE_LABEL);
+        tokenValue.append("=");
+        tokenValue.append(new String(Base64.encode(sig)));
+
+        String token = "base64:" + String.valueOf(Base64.encode(tokenValue.toString().getBytes()));
+
+        log.debug("valid token: " + token);
+        DelegationToken actToken = DelegationToken.parse(token, null);
+
+        assertEquals("User id not the same", httpPrincipal, actToken.getUser());
+        assertEquals("Expiry time not the same", expiry.getTime().getTime(),
+                     actToken.getExpiryTime().getTime());
+        assertEquals("Scope not the same", scope, actToken.getScope());
+        assertEquals("Domain list size not the same", domainList.size(), actToken.getDomains().size());
+        assertArrayEquals("Wrong set of domains.", domainList.toArray(new String[0]),
+                          actToken.getDomains().toArray(new String[0]));
     }
 
     @Test
@@ -181,7 +241,7 @@ public class DelegationTokenTest {
                      actToken.getScope());
         assertEquals("Domain list size not the same", domainList.size(), expToken.getDomains().size());
         for (String domain : expToken.getDomains()) {
-            Assert.assertTrue("Domain list content not the same", domainList.contains(domain));
+            assertTrue("Domain list content not the same", domainList.contains(domain));
         }
 
 
@@ -272,7 +332,6 @@ public class DelegationTokenTest {
             expToken = new DelegationToken(userid, scope, expiry.getTime(), null);
 
             token = DelegationToken.format(expToken);
-            char toReplace = token.charAt(token.indexOf("signature") + 10);
             token = token.substring(0, token.length() - 1);
             token = token + "A";
 
@@ -314,10 +373,10 @@ public class DelegationTokenTest {
         final String tokenValue = DelegationToken.format(delegationToken);
 
         for (final char c : ILLEGAL_COOKIE_CHARACTERS) {
-            Assert.assertFalse(String.format("Token %s invalid characters (%s).",
-                                             tokenValue,
-                                             Arrays.toString(ILLEGAL_COOKIE_CHARACTERS)),
-                               tokenValue.contains(Character.toString(c)));
+            assertFalse(String.format("Token %s invalid characters (%s).",
+                                      tokenValue,
+                                      Arrays.toString(ILLEGAL_COOKIE_CHARACTERS)),
+                        tokenValue.contains(Character.toString(c)));
         }
 
         final DelegationToken parsedDelegationToken = DelegationToken.parse(tokenValue, null);

--- a/cadc-util/src/test/java/ca/nrc/cadc/auth/SSOCookieManagerTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/auth/SSOCookieManagerTest.java
@@ -1,71 +1,71 @@
 /*
-************************************************************************
-*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
-**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
-*
-*  (c) 2018.                            (c) 2018.
-*  Government of Canada                 Gouvernement du Canada
-*  National Research Council            Conseil national de recherches
-*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
-*  All rights reserved                  Tous droits réservés
-*
-*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
-*  expressed, implied, or               énoncée, implicite ou légale,
-*  statutory, of any kind with          de quelque nature que ce
-*  respect to the software,             soit, concernant le logiciel,
-*  including without limitation         y compris sans restriction
-*  any warranty of merchantability      toute garantie de valeur
-*  or fitness for a particular          marchande ou de pertinence
-*  purpose. NRC shall not be            pour un usage particulier.
-*  liable in any event for any          Le CNRC ne pourra en aucun cas
-*  damages, whether direct or           être tenu responsable de tout
-*  indirect, special or general,        dommage, direct ou indirect,
-*  consequential or incidental,         particulier ou général,
-*  arising from the use of the          accessoire ou fortuit, résultant
-*  software.  Neither the name          de l'utilisation du logiciel. Ni
-*  of the National Research             le nom du Conseil National de
-*  Council of Canada nor the            Recherches du Canada ni les noms
-*  names of its contributors may        de ses  participants ne peuvent
-*  be used to endorse or promote        être utilisés pour approuver ou
-*  products derived from this           promouvoir les produits dérivés
-*  software without specific prior      de ce logiciel sans autorisation
-*  written permission.                  préalable et particulière
-*                                       par écrit.
-*
-*  This file is part of the             Ce fichier fait partie du projet
-*  OpenCADC project.                    OpenCADC.
-*
-*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
-*  you can redistribute it and/or       vous pouvez le redistribuer ou le
-*  modify it under the terms of         modifier suivant les termes de
-*  the GNU Affero General Public        la “GNU Affero General Public
-*  License as published by the          License” telle que publiée
-*  Free Software Foundation,            par la Free Software Foundation
-*  either version 3 of the              : soit la version 3 de cette
-*  License, or (at your option)         licence, soit (à votre gré)
-*  any later version.                   toute version ultérieure.
-*
-*  OpenCADC is distributed in the       OpenCADC est distribué
-*  hope that it will be useful,         dans l’espoir qu’il vous
-*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
-*  without even the implied             GARANTIE : sans même la garantie
-*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
-*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
-*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
-*  General Public License for           Générale Publique GNU Affero
-*  more details.                        pour plus de détails.
-*
-*  You should have received             Vous devriez avoir reçu une
-*  a copy of the GNU Affero             copie de la Licence Générale
-*  General Public License along         Publique GNU Affero avec
-*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
-*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
-*                                       <http://www.gnu.org/licenses/>.
-*
-*  $Revision: 5 $
-*
-************************************************************************
-*/
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2018.                            (c) 2018.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  $Revision: 5 $
+ *
+ ************************************************************************
+ */
 
 package ca.nrc.cadc.auth;
 
@@ -75,9 +75,11 @@ import ca.nrc.cadc.util.Log4jInit;
 import ca.nrc.cadc.util.PropertiesReader;
 import ca.nrc.cadc.util.RSASignatureGeneratorValidatorTest;
 import ca.nrc.cadc.util.RsaSignatureGenerator;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
 import java.security.InvalidKeyException;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -89,27 +91,27 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import javax.security.auth.x500.X500Principal;
+
 import org.apache.log4j.Level;
 import org.junit.After;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
+
 import org.junit.Before;
 
 
-public class SSOCookieManagerTest
-{    
-    static
-    {
+public class SSOCookieManagerTest {
+    static {
         Log4jInit.setLevel("ca.nrc.cadc.auth", Level.INFO);
     }
-    
+
     File pubFile, privFile;
 
     List<String> domainList = new ArrayList<>();
 
     @Before
-    public void initKeys() throws Exception
-    {
+    public void initKeys() throws Exception {
         String keysDir = RSASignatureGeneratorValidatorTest.getCompleteKeysDirectoryName();
         RsaSignatureGenerator.genKeyPair(keysDir);
         privFile = new File(keysDir, RsaSignatureGenerator.PRIV_KEY_FILE_NAME);
@@ -121,17 +123,15 @@ public class SSOCookieManagerTest
         domainList.add("cadc-ccda.hia-iha.nrc-cnrc.gc.ca");
 
     }
-    
+
     @After
-    public void cleanupKeys() throws Exception
-    {
+    public void cleanupKeys() throws Exception {
         pubFile.delete();
         privFile.delete();
     }
-    
+
     @Test
-    public void roundTripMin() throws Exception
-    {
+    public void roundTripMin() throws Exception {
         final HttpPrincipal userPrincipal = new HttpPrincipal("CADCtest");
         SSOCookieManager cm = new SSOCookieManager();
         DelegationToken cookieToken = cm.parse(cm.generate(userPrincipal, null));
@@ -142,10 +142,10 @@ public class SSOCookieManagerTest
     }
 
     @Test
-    public void roundTrip() throws Exception
-    {
+    public void roundTrip() throws Exception {
+        loadDomainsProperties();
+
         SSOCookieManager cm = new SSOCookieManager();
-        System.setProperty(PropertiesReader.CONFIG_DIR_SYSTEM_PROPERTY, "./build/resources/test");
 
         // round trip test
         Set<Principal> testPrincipals = new HashSet<>();
@@ -170,11 +170,27 @@ public class SSOCookieManagerTest
         assertEquals("domain list not equal", domainList, actToken.getDomains());
     }
 
+    /**
+     * Method to ensure the ac-domains.properties is loaded from the test resources classpath.
+     *
+     * @throws IOException If it cannot be loaded.
+     */
+    private void loadDomainsProperties() throws IOException {
+        // Set properties file location.
+        final URL resourceURL =
+            SSOCookieManagerTest.class.getClassLoader().getResource("ac-domains.properties");
+
+        if (resourceURL == null) {
+            throw new IOException("No ac-domains.properties in classpath.");
+        }
+
+        final String domainsPath = resourceURL.getPath();
+        System.setProperty(PropertiesReader.CONFIG_DIR_SYSTEM_PROPERTY, new File(domainsPath).getParent());
+    }
 
     public String createCookieString() throws InvalidKeyException, IOException {
 
-        // Set properties file location.
-        System.setProperty(PropertiesReader.CONFIG_DIR_SYSTEM_PROPERTY, "./build/resources/test");
+        loadDomainsProperties();
         // get the properties
         PropertiesReader propReader = new PropertiesReader(SSOCookieManager.DOMAINS_PROP_FILE);
         List<String> propertyValues = propReader.getPropertyValues("domains");
@@ -184,7 +200,11 @@ public class SSOCookieManagerTest
         Date cookieExpiry = new Date(baseTime.getTime() + (48 * 3600 * 1000));
         String testCookieStringDate = DelegationToken.EXPIRY_LABEL + "=" + cookieExpiry.getTime();
 
-        String testCookieStringBody ="&" + DelegationToken.USER_LABEL + "=someuser&" +
+        final Set<Principal> principals = new HashSet<>();
+        principals.add(new HttpPrincipal("someuser"));
+
+        String testCookieStringBody = "&" + DelegationToken.IDENTITIES_LABEL + "=" +
+            String.valueOf(DelegationToken.encodePrincipals(principals)) + "&" +
             DelegationToken.DOMAIN_LABEL + "=" + domainList.get(0) + "&" +
             DelegationToken.DOMAIN_LABEL + "=" + domainList.get(1) + "&" +
             DelegationToken.DOMAIN_LABEL + "=" + domainList.get(2) + "&" +
@@ -215,9 +235,7 @@ public class SSOCookieManagerTest
 
             // cookieList length should be same as list of expected domains
             assertEquals(cookieList.size(), domainList.size());
-        }
-        finally
-        {
+        } finally {
             System.setProperty(PropertiesReader.class.getName() + ".dir", "");
         }
     }

--- a/cadc-util/src/test/java/ca/nrc/cadc/auth/SSOCookieManagerTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/auth/SSOCookieManagerTest.java
@@ -1,71 +1,71 @@
 /*
- ************************************************************************
- *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
- **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
- *
- *  (c) 2018.                            (c) 2018.
- *  Government of Canada                 Gouvernement du Canada
- *  National Research Council            Conseil national de recherches
- *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
- *  All rights reserved                  Tous droits réservés
- *
- *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
- *  expressed, implied, or               énoncée, implicite ou légale,
- *  statutory, of any kind with          de quelque nature que ce
- *  respect to the software,             soit, concernant le logiciel,
- *  including without limitation         y compris sans restriction
- *  any warranty of merchantability      toute garantie de valeur
- *  or fitness for a particular          marchande ou de pertinence
- *  purpose. NRC shall not be            pour un usage particulier.
- *  liable in any event for any          Le CNRC ne pourra en aucun cas
- *  damages, whether direct or           être tenu responsable de tout
- *  indirect, special or general,        dommage, direct ou indirect,
- *  consequential or incidental,         particulier ou général,
- *  arising from the use of the          accessoire ou fortuit, résultant
- *  software.  Neither the name          de l'utilisation du logiciel. Ni
- *  of the National Research             le nom du Conseil National de
- *  Council of Canada nor the            Recherches du Canada ni les noms
- *  names of its contributors may        de ses  participants ne peuvent
- *  be used to endorse or promote        être utilisés pour approuver ou
- *  products derived from this           promouvoir les produits dérivés
- *  software without specific prior      de ce logiciel sans autorisation
- *  written permission.                  préalable et particulière
- *                                       par écrit.
- *
- *  This file is part of the             Ce fichier fait partie du projet
- *  OpenCADC project.                    OpenCADC.
- *
- *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
- *  you can redistribute it and/or       vous pouvez le redistribuer ou le
- *  modify it under the terms of         modifier suivant les termes de
- *  the GNU Affero General Public        la “GNU Affero General Public
- *  License as published by the          License” telle que publiée
- *  Free Software Foundation,            par la Free Software Foundation
- *  either version 3 of the              : soit la version 3 de cette
- *  License, or (at your option)         licence, soit (à votre gré)
- *  any later version.                   toute version ultérieure.
- *
- *  OpenCADC is distributed in the       OpenCADC est distribué
- *  hope that it will be useful,         dans l’espoir qu’il vous
- *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
- *  without even the implied             GARANTIE : sans même la garantie
- *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
- *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
- *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
- *  General Public License for           Générale Publique GNU Affero
- *  more details.                        pour plus de détails.
- *
- *  You should have received             Vous devriez avoir reçu une
- *  a copy of the GNU Affero             copie de la Licence Générale
- *  General Public License along         Publique GNU Affero avec
- *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
- *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
- *                                       <http://www.gnu.org/licenses/>.
- *
- *  $Revision: 5 $
- *
- ************************************************************************
- */
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2018.                            (c) 2018.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+*  $Revision: 5 $
+*
+************************************************************************
+*/
 
 package ca.nrc.cadc.auth;
 

--- a/cadc-util/src/test/java/ca/nrc/cadc/auth/SSOCookieManagerTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/auth/SSOCookieManagerTest.java
@@ -75,11 +75,9 @@ import ca.nrc.cadc.util.Log4jInit;
 import ca.nrc.cadc.util.PropertiesReader;
 import ca.nrc.cadc.util.RSASignatureGeneratorValidatorTest;
 import ca.nrc.cadc.util.RsaSignatureGenerator;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.security.InvalidKeyException;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -91,27 +89,27 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import javax.security.auth.x500.X500Principal;
-
 import org.apache.log4j.Level;
 import org.junit.After;
 import org.junit.Test;
-
 import static org.junit.Assert.*;
-
 import org.junit.Before;
 
 
-public class SSOCookieManagerTest {
-    static {
+public class SSOCookieManagerTest
+{    
+    static
+    {
         Log4jInit.setLevel("ca.nrc.cadc.auth", Level.INFO);
     }
-
+    
     File pubFile, privFile;
 
     List<String> domainList = new ArrayList<>();
 
     @Before
-    public void initKeys() throws Exception {
+    public void initKeys() throws Exception
+    {
         String keysDir = RSASignatureGeneratorValidatorTest.getCompleteKeysDirectoryName();
         RsaSignatureGenerator.genKeyPair(keysDir);
         privFile = new File(keysDir, RsaSignatureGenerator.PRIV_KEY_FILE_NAME);
@@ -123,15 +121,17 @@ public class SSOCookieManagerTest {
         domainList.add("cadc-ccda.hia-iha.nrc-cnrc.gc.ca");
 
     }
-
+    
     @After
-    public void cleanupKeys() throws Exception {
+    public void cleanupKeys()
+    {
         pubFile.delete();
         privFile.delete();
     }
-
+    
     @Test
-    public void roundTripMin() throws Exception {
+    public void roundTripMin() throws Exception
+    {
         final HttpPrincipal userPrincipal = new HttpPrincipal("CADCtest");
         SSOCookieManager cm = new SSOCookieManager();
         DelegationToken cookieToken = cm.parse(cm.generate(userPrincipal, null));
@@ -142,10 +142,10 @@ public class SSOCookieManagerTest {
     }
 
     @Test
-    public void roundTrip() throws Exception {
-        loadDomainsProperties();
-
+    public void roundTrip() throws Exception
+    {
         SSOCookieManager cm = new SSOCookieManager();
+        System.setProperty(PropertiesReader.CONFIG_DIR_SYSTEM_PROPERTY, "./build/resources/test");
 
         // round trip test
         Set<Principal> testPrincipals = new HashSet<>();
@@ -170,27 +170,10 @@ public class SSOCookieManagerTest {
         assertEquals("domain list not equal", domainList, actToken.getDomains());
     }
 
-    /**
-     * Method to ensure the ac-domains.properties is loaded from the test resources classpath.
-     *
-     * @throws IOException If it cannot be loaded.
-     */
-    private void loadDomainsProperties() throws IOException {
-        // Set properties file location.
-        final URL resourceURL =
-            SSOCookieManagerTest.class.getClassLoader().getResource("ac-domains.properties");
-
-        if (resourceURL == null) {
-            throw new IOException("No ac-domains.properties in classpath.");
-        }
-
-        final String domainsPath = resourceURL.getPath();
-        System.setProperty(PropertiesReader.CONFIG_DIR_SYSTEM_PROPERTY, new File(domainsPath).getParent());
-    }
-
     public String createCookieString() throws InvalidKeyException, IOException {
 
-        loadDomainsProperties();
+        // Set properties file location.
+        System.setProperty(PropertiesReader.CONFIG_DIR_SYSTEM_PROPERTY, "./build/resources/test");
         // get the properties
         PropertiesReader propReader = new PropertiesReader(SSOCookieManager.DOMAINS_PROP_FILE);
         List<String> propertyValues = propReader.getPropertyValues("domains");
@@ -200,11 +183,7 @@ public class SSOCookieManagerTest {
         Date cookieExpiry = new Date(baseTime.getTime() + (48 * 3600 * 1000));
         String testCookieStringDate = DelegationToken.EXPIRY_LABEL + "=" + cookieExpiry.getTime();
 
-        final Set<Principal> principals = new HashSet<>();
-        principals.add(new HttpPrincipal("someuser"));
-
-        String testCookieStringBody = "&" + DelegationToken.IDENTITIES_LABEL + "=" +
-            String.valueOf(DelegationToken.encodePrincipals(principals)) + "&" +
+        String testCookieStringBody ="&" + DelegationToken.USER_LABEL + "=someuser&" +
             DelegationToken.DOMAIN_LABEL + "=" + domainList.get(0) + "&" +
             DelegationToken.DOMAIN_LABEL + "=" + domainList.get(1) + "&" +
             DelegationToken.DOMAIN_LABEL + "=" + domainList.get(2) + "&" +
@@ -235,7 +214,9 @@ public class SSOCookieManagerTest {
 
             // cookieList length should be same as list of expected domains
             assertEquals(cookieList.size(), domainList.size());
-        } finally {
+        }
+        finally
+        {
             System.setProperty(PropertiesReader.class.getName() + ".dir", "");
         }
     }


### PR DESCRIPTION
The tests were updated to reflect this RFC:
https://tools.ietf.org/html/rfc6265

The identities are encoded and placed in an `identities=` key in the token value.

Rather than the identities being placed directly as before:
expirytime=`EXPIRYTIME`&X500=`DISTINGUISHED_NAME_IDENTITY`&numericID=`NUMERIC_IDENTITY`&userID=`HTTP_USERNAME_IDENTITY`&scope=`SCOPE`&domain=`DOMAINS[]`&signature=`ENCODED_SIGNATURE`

The value now looks like:
expirytime=`EXPIRYTIME`&identities=`ENCODED_SET_OF_IDENTITIES`&scope=`SCOPE`&domain=`DOMAINS[]`&signature=`ENCODED_SIGNATURE`