### PR TITLE
S2325

### DIFF
--- a/cadc-util/build.gradle
+++ b/cadc-util/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.2.0'
+version = '1.2.1'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/cadc-util/src/main/java/ca/nrc/cadc/xml/JsonInputter.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/xml/JsonInputter.java
@@ -92,13 +92,6 @@ public class JsonInputter
     {
     }
 
-    private final Map<String, String> listElementMap = new TreeMap<String, String>();
-
-    public Map<String, String> getListElementMap()
-    {
-        return listElementMap;
-    }
-
     public Document input(final String json)
             throws JSONException
     {
@@ -169,22 +162,7 @@ public class JsonInputter
             return;
         }
 
-        if (listElementMap.containsKey(key))
-        {
-            final Object childObject = ((JSONObject) value).get("$");
-            //        ((JSONObject) value).get(listElementMap.get(key));
-
-            if (childObject instanceof JSONArray)
-            {
-                processJSONArray(key, (JSONArray) childObject, element,
-                                 namespace, namespaces);
-            }
-            else if (childObject instanceof JSONObject)
-            {
-                processJSONObject((JSONObject) childObject, element, namespaces);
-            }
-        }
-        else if (value instanceof JSONObject)
+        if (value instanceof JSONObject)
         {
             processJSONObject((JSONObject) value, element, namespaces);
         }
@@ -270,60 +248,12 @@ public class JsonInputter
             }
 
             Element child = new Element(key, namespace);
-            if (listElementMap.containsKey(key))
-            {
-                final String childKey = listElementMap.get(key);
-                final Object childObject = ((JSONObject) value).get("$");
-                Element grandChild = new Element(childKey, namespace);
-
-                if (childObject instanceof JSONArray)
-                {
-                    processJSONArray(key, (JSONArray) childObject, child,
-                                     namespace, namespaces);
-                }
-                else if (childObject instanceof JSONObject)
-                {
-                    processJSONObject((JSONObject) childObject, grandChild,
-                                      namespaces);
-                    child.addContent(grandChild);
-                }
-            }
-            else if (value instanceof JSONObject)
+            if (value instanceof JSONObject)
             {
                 processJSONObject((JSONObject) value, child, namespaces);
             }
 
             element.addContent(child);
-        }
-    }
-
-    private void processJSONArray(String key, JSONArray jsonArray,
-                                  Element arrayElement,
-                                  Namespace namespace, List<Namespace> namespaces)
-            throws JSONException
-    {
-        String childTypeName = getListElementMap().get(key);
-
-        for (int i = 0; i < jsonArray.length(); i++)
-        {
-            if (jsonArray.isNull(i))
-            {
-                continue;
-            }
-
-            Element child;
-            if (childTypeName == null)
-            {
-                child = arrayElement;
-            }
-            else
-            {
-                child = new Element(childTypeName, namespace);
-                arrayElement.addContent(child);
-            }
-
-            Object value = jsonArray.get(i);
-            processObject(childTypeName, value, child, namespace, namespaces);
         }
     }
 

--- a/cadc-util/src/main/java/ca/nrc/cadc/xml/JsonInputter.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/xml/JsonInputter.java
@@ -80,8 +80,6 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * JsonInputter

--- a/cadc-util/src/test/java/ca/nrc/cadc/xml/JsonOutputterTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/xml/JsonOutputterTest.java
@@ -103,9 +103,6 @@ public class JsonOutputterTest
         jsonOut.getListElementNames().add("items");
         jsonOut.getStringElementNames().add("item");
         
-        JsonInputter jsonIn = new JsonInputter();
-        jsonIn.getListElementMap().put("items", "item");
-        
         final Writer writer = new StringWriter();
 
         jsonOut.output(document, writer);


### PR DESCRIPTION
Removed listElementMap and related code. listElementMap was the previous way to recover the name of an item in an array of items.

- unit tests in cadc-access-control pass after an update; pull request to follow
- unit tests in caom2/caom2 pass
- unit tests in vos/cadc-vos pass
- unit tests in service/doi pass
- integration tests in service/caom2ops pass
- integration tests in service/vospace pass