### PR TITLE
Add BearerTokenPrincipal

### DIFF
--- a/cadc-util/build.gradle
+++ b/cadc-util/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.2.17'
+version = '1.2.18'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'

--- a/cadc-util/src/main/java/ca/nrc/cadc/auth/AuthenticationUtil.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/auth/AuthenticationUtil.java
@@ -112,6 +112,9 @@ public class AuthenticationUtil
 
     public static final String AUTH_HEADER = "X-CADC-DelegationToken";
 
+    // HTTP/1.1 Authorization header as defined by RFC 7235
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
     // Mandatory support list of RDN descriptors according to RFC 4512.
     private static final String[] ORDERED_RDN_KEYS = new String[]
     {

--- a/cadc-util/src/main/java/ca/nrc/cadc/auth/BearerTokenPrincipal.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/auth/BearerTokenPrincipal.java
@@ -1,0 +1,144 @@
+/*
+ ************************************************************************
+ *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+ **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+ *
+ *  (c) 2019.                            (c) 2019.
+ *  Government of Canada                 Gouvernement du Canada
+ *  National Research Council            Conseil national de recherches
+ *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+ *  All rights reserved                  Tous droits réservés
+ *
+ *  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+ *  expressed, implied, or               énoncée, implicite ou légale,
+ *  statutory, of any kind with          de quelque nature que ce
+ *  respect to the software,             soit, concernant le logiciel,
+ *  including without limitation         y compris sans restriction
+ *  any warranty of merchantability      toute garantie de valeur
+ *  or fitness for a particular          marchande ou de pertinence
+ *  purpose. NRC shall not be            pour un usage particulier.
+ *  liable in any event for any          Le CNRC ne pourra en aucun cas
+ *  damages, whether direct or           être tenu responsable de tout
+ *  indirect, special or general,        dommage, direct ou indirect,
+ *  consequential or incidental,         particulier ou général,
+ *  arising from the use of the          accessoire ou fortuit, résultant
+ *  software.  Neither the name          de l'utilisation du logiciel. Ni
+ *  of the National Research             le nom du Conseil National de
+ *  Council of Canada nor the            Recherches du Canada ni les noms
+ *  names of its contributors may        de ses  participants ne peuvent
+ *  be used to endorse or promote        être utilisés pour approuver ou
+ *  products derived from this           promouvoir les produits dérivés
+ *  software without specific prior      de ce logiciel sans autorisation
+ *  written permission.                  préalable et particulière
+ *                                       par écrit.
+ *
+ *  This file is part of the             Ce fichier fait partie du projet
+ *  OpenCADC project.                    OpenCADC.
+ *
+ *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+ *  you can redistribute it and/or       vous pouvez le redistribuer ou le
+ *  modify it under the terms of         modifier suivant les termes de
+ *  the GNU Affero General Public        la “GNU Affero General Public
+ *  License as published by the          License” telle que publiée
+ *  Free Software Foundation,            par la Free Software Foundation
+ *  either version 3 of the              : soit la version 3 de cette
+ *  License, or (at your option)         licence, soit (à votre gré)
+ *  any later version.                   toute version ultérieure.
+ *
+ *  OpenCADC is distributed in the       OpenCADC est distribué
+ *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+ *  without even the implied             GARANTIE : sans même la garantie
+ *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+ *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+ *  General Public License for           Générale Publique GNU Affero
+ *  more details.                        pour plus de détails.
+ *
+ *  You should have received             Vous devriez avoir reçu une
+ *  a copy of the GNU Affero             copie de la Licence Générale
+ *  General Public License along         Publique GNU Affero avec
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+ *                                       <http://www.gnu.org/licenses/>.
+ *
+ *  $Revision: 1$
+ *
+ ************************************************************************
+ */
+package ca.nrc.cadc.auth;
+
+import ca.nrc.cadc.util.StringUtil;
+
+import java.io.Serializable;
+import java.security.Principal;
+
+
+/**
+ * Represents a bearer token
+ */
+public class BearerTokenPrincipal implements Principal, Serializable
+{
+    private static final long serialVersionUID = 7L;
+    private static final String prefix = "Bearer ";
+
+    private final String token;
+
+
+    public BearerTokenPrincipal(final String authorizationHeader)
+    {
+        if (!isBearerToken(authorizationHeader))
+        {
+            throw new IllegalArgumentException("Not a bearer token");
+        }
+
+        this.token = authorizationHeader.substring(prefix.length());
+    }
+
+    public static Boolean isBearerToken(final String authorizationHeader)
+    {
+        return StringUtil.hasText(authorizationHeader) &&
+               authorizationHeader.startsWith(prefix);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "BearerTokenPrincipal[" + getName().substring(0, 8) + "]";
+    }
+
+    /**
+     * Returns the full token for this principal
+     *
+     * @return the full token as a string
+     */
+    @Override
+    public String getName()
+    {
+        return token;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+
+        if ((o == null) || (getClass() != o.getClass()))
+        {
+            return false;
+        }
+
+        final BearerTokenPrincipal that = (BearerTokenPrincipal) o;
+
+        return token.equals(that.token);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return token.hashCode();
+    }
+}

--- a/cadc-util/src/main/java/ca/nrc/cadc/auth/ServletPrincipalExtractor.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/auth/ServletPrincipalExtractor.java
@@ -164,6 +164,12 @@ public class ServletPrincipalExtractor implements PrincipalExtractor
             finally { }
         }
 
+        String authToken = request.getHeader(AuthenticationUtil.AUTHORIZATION_HEADER);
+        if ( BearerTokenPrincipal.isBearerToken(authToken) )
+        {
+            principals.add(new BearerTokenPrincipal(authToken));
+        }
+
         // add HttpPrincipal
         final String httpUser = request.getRemoteUser();
         if (StringUtil.hasText(httpUser)) // user from HTTP AUTH

--- a/cadc-util/src/test/java/ca/nrc/cadc/auth/AuthenticationUtilTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/auth/AuthenticationUtilTest.java
@@ -448,6 +448,7 @@ public class AuthenticationUtilTest
             expect(mockRequest.getRemoteUser()).andReturn(null).atLeastOnce();
             expect(mockRequest.getCookies()).andReturn(null).atLeastOnce();
             expect(mockRequest.getHeader(AuthenticationUtil.AUTH_HEADER)).andReturn(null).atLeastOnce();
+            expect(mockRequest.getHeader("Authorization")).andReturn(null);
             expect(mockRequest.getAttribute(
                     "javax.servlet.request.X509Certificate")).andReturn(null).atLeastOnce();
             
@@ -488,6 +489,7 @@ public class AuthenticationUtilTest
             expect(mockRequest.getRemoteUser()).andReturn(null).atLeastOnce();
             expect(mockRequest.getCookies()).andReturn(null).atLeastOnce();
             expect(mockRequest.getHeader(AuthenticationUtil.AUTH_HEADER)).andReturn(null).atLeastOnce();
+            expect(mockRequest.getHeader("Authorization")).andReturn(null);
             expect(mockRequest.getAttribute(
                     "javax.servlet.request.X509Certificate")).andReturn(null).atLeastOnce();
             
@@ -527,6 +529,7 @@ public class AuthenticationUtilTest
             expect(mockRequest.getRemoteUser()).andReturn("foo").atLeastOnce();
             expect(mockRequest.getCookies()).andReturn(null).atLeastOnce();
             expect(mockRequest.getHeader(AuthenticationUtil.AUTH_HEADER)).andReturn(null).atLeastOnce();
+            expect(mockRequest.getHeader("Authorization")).andReturn(null);
             expect(mockRequest.getAttribute(
                     "javax.servlet.request.X509Certificate")).andReturn(null).atLeastOnce();
 
@@ -699,6 +702,7 @@ public class AuthenticationUtilTest
             expect(mockRequest.getRemoteUser()).andReturn(null).atLeastOnce();
             expect(mockRequest.getCookies()).andReturn(null).atLeastOnce();
             expect(mockRequest.getHeader(AuthenticationUtil.AUTH_HEADER)).andReturn(null).atLeastOnce();
+            expect(mockRequest.getHeader("Authorization")).andReturn(null);
             expect(mockRequest.getAttribute(
                     "javax.servlet.request.X509Certificate")).andReturn(ca).atLeastOnce();
             expect(mockCertificate.getNotAfter()).andReturn(notAfterDate).once();
@@ -784,6 +788,7 @@ public class AuthenticationUtilTest
             expect(mockRequest.getRemoteUser()).andReturn(null).atLeastOnce();
             expect(mockRequest.getCookies()).andReturn(cookies).atLeastOnce();
             expect(mockRequest.getHeader(AuthenticationUtil.AUTH_HEADER)).andReturn(null).atLeastOnce();
+            expect(mockRequest.getHeader("Authorization")).andReturn(null);
             expect(mockRequest.getAttribute(
                     "javax.servlet.request.X509Certificate")).andReturn(null).atLeastOnce();
 

--- a/cadc-util/src/test/java/ca/nrc/cadc/auth/BearerTokenPrincipalTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/auth/BearerTokenPrincipalTest.java
@@ -1,0 +1,155 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2019.                            (c) 2019.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+*  $Revision: 1 $
+*
+************************************************************************
+*/
+
+package ca.nrc.cadc.auth;
+
+import ca.nrc.cadc.util.Log4jInit;
+import junit.framework.Assert;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Test;
+
+/**
+ *
+ * @author cbanek
+ */
+public class BearerTokenPrincipalTest
+{
+    private static Logger log = Logger.getLogger(BearerTokenPrincipalTest.class);
+
+    // A pretend bearer token Authorization header value
+    private final static String bearerAuthorization = "Bearer 12345678-new-luggage-combo";
+    private final static String bearerName = "12345678-new-luggage-combo";
+    private final static String bearerStringRepr = "BearerTokenPrincipal[12345678]";
+
+    // A pretend basic auth Authorization header value
+    private final static String basicAuthorization = "Basic not-the-one";
+
+    static
+    {
+        Log4jInit.setLevel("ca.nrc.cadc.auth", Level.INFO);
+        Log4jInit.setLevel("ca.nrc.cadc.util", Level.INFO);
+    }
+
+    public BearerTokenPrincipalTest()
+    {
+
+    }
+
+    @Test
+    public void testParseBearerToken()
+    {
+        log.debug("testParseBearerToken - START");
+        try
+        {
+            // Test parsing and access
+            BearerTokenPrincipal btp = new BearerTokenPrincipal(bearerAuthorization);
+            Assert.assertEquals(btp.getName(), bearerName);
+            Assert.assertEquals(btp.toString(), bearerStringRepr);
+
+            // Test equality
+            BearerTokenPrincipal btp2 = new BearerTokenPrincipal(bearerAuthorization);
+            Assert.assertEquals(btp, btp2);
+        }
+        catch(Exception unexpected)
+        {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+        finally
+        {
+            log.debug("testParseBearerToken - DONE");
+        }
+    }
+
+    @Test
+    public void testInvalidBearerToken()
+    {
+        log.debug("testInvalidBearerToken - START");
+        try
+        {
+            BearerTokenPrincipal btp = new BearerTokenPrincipal(basicAuthorization);
+            throw new Exception("Should have thrown already.");
+        }
+        catch(IllegalArgumentException expected)
+        {
+            Assert.assertEquals(expected.getMessage(), "Not a bearer token");
+        }
+        catch(Exception unexpected)
+        {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+        finally
+        {
+            log.debug("testInvalidBearerToken - DONE");
+        }
+    }
+}

--- a/cadc-util/src/test/java/ca/nrc/cadc/auth/ServletPrincipalExtractorTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/auth/ServletPrincipalExtractorTest.java
@@ -96,6 +96,7 @@ public class ServletPrincipalExtractorTest
             expect(request.getAttribute(
                     ServletPrincipalExtractor.CERT_REQUEST_ATTRIBUTE)).andReturn(null);
             expect(request.getHeader(AuthenticationUtil.AUTH_HEADER)).andReturn(null);
+            expect(request.getHeader("Authorization")).andReturn(null);
             expect(request.getCookies()).andReturn(cookies);
             expect(request.getRemoteUser()).andReturn(null).times(2);
             expect(request.getServerName()).andReturn("cookiedomain").once();
@@ -129,6 +130,7 @@ public class ServletPrincipalExtractorTest
             expect(request.getAttribute(
                     ServletPrincipalExtractor.CERT_REQUEST_ATTRIBUTE)).andReturn(null);
             expect(request.getHeader(AuthenticationUtil.AUTH_HEADER)).andReturn(null);
+            expect(request.getHeader("Authorization")).andReturn(null);
             expect(request.getCookies()).andReturn(cookies2);
             expect(request.getRemoteUser()).andReturn(null).atLeastOnce();
             expect(cookie.getName()).


### PR DESCRIPTION
Add a BearerTokenPrincipal, which is just the authorization header
set with something that starts with Bearer.  This is automatically
pulled out in the ServletPrincipalExtractor and presented as a
Principal on the subject.