### PR TITLE
Augment subject when making LogControl requests

### DIFF
--- a/cadc-log/build.gradle
+++ b/cadc-log/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.1.1'
+version = '1.1.2'
 
 dependencies {
     compile 'log4j:log4j:[1.2,)'

--- a/cadc-log/src/main/java/ca/nrc/cadc/log/LogControlServlet.java
+++ b/cadc-log/src/main/java/ca/nrc/cadc/log/LogControlServlet.java
@@ -373,8 +373,17 @@ public class LogControlServlet extends HttpServlet {
     private void authorize(HttpServletRequest request, boolean readOnly)
         throws AccessControlException, TransientException {
 
-        // Get the calling subject.
-        Subject subject = AuthenticationUtil.getSubject(request);
+        // Get the calling subject.  If possible, augment the subject,
+        // but if augmenting fails, use the subject provided only.
+        Subject subject;
+
+        try {
+            subject = AuthenticationUtil.getSubject(request);
+        } catch (Exception e) {
+            logger.error("Augment subject failed, using non-augmented subject: " + e.getMessage());
+            subject = AuthenticationUtil.getSubject(request, false);
+        }
+
         logger.debug(subject.toString());
 
         // Get the logControl properties if they exist.

--- a/cadc-log/src/main/java/ca/nrc/cadc/log/LogControlServlet.java
+++ b/cadc-log/src/main/java/ca/nrc/cadc/log/LogControlServlet.java
@@ -374,7 +374,7 @@ public class LogControlServlet extends HttpServlet {
         throws AccessControlException, TransientException {
 
         // Get the calling subject.
-        Subject subject = AuthenticationUtil.getSubject(request, false);
+        Subject subject = AuthenticationUtil.getSubject(request);
         logger.debug(subject.toString());
 
         // Get the logControl properties if they exist.


### PR DESCRIPTION
So in the LogControlServlet, when a post or a get happens, the auth
data and AuthenticatorImpl are used, but by passing in false to
getSubject, the subject is not augmented.

For LSST, we start off with a token credential, then when we augment
this we pull out data such as the username, userid, etc.  So to have
the username to check against, the subject must be augmented.