### PR TITLE
fix HttpGet headOnly mode bug when run() used

### DIFF
--- a/cadc-http-client/build.gradle
+++ b/cadc-http-client/build.gradle
@@ -19,7 +19,7 @@ mainClassName = 'ca.nrc.cadc.net.Main'
 
 dependencies {
     compile 'log4j:log4j:1.2.17'
-    compile 'org.opencadc:cadc-util:[1.0.8,1.3)'
+    compile 'org.opencadc:cadc-util:[1.3.1,1.4)'
     
     testCompile 'junit:junit:4.13'
 }

--- a/cadc-rest/build.gradle
+++ b/cadc-rest/build.gradle
@@ -17,7 +17,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.2.15'
+version = '1.2.16'
 
 dependencies {
     compile 'commons-fileupload:commons-fileupload:1.4'

--- a/cadc-rest/src/main/java/ca/nrc/cadc/rest/RestAction.java
+++ b/cadc-rest/src/main/java/ca/nrc/cadc/rest/RestAction.java
@@ -265,7 +265,7 @@ public abstract class RestAction implements PrivilegedExceptionAction<Object> {
             handleException(ex, 403, "permission denied -- reason: invalid proxy certficate", false, true);
         } catch (IllegalArgumentException ex) {
             logInfo.setSuccess(true);
-            handleException(ex, 400, ex.getMessage(), false, true);
+            handleException(ex, 400, ex.getMessage(), false, false);
         } catch (ResourceNotFoundException ex) {
             logInfo.setSuccess(true);
             handleException(ex, 404, ex.getMessage(), false, false);
@@ -327,7 +327,7 @@ public abstract class RestAction implements PrivilegedExceptionAction<Object> {
 
             OutputStream os = syncOutput.getOutputStream();
             StringBuilder sb = new StringBuilder();
-            sb.append(message);
+            sb.append(message).append("\n");
 
             if (showExceptions) {
                 sb.append(ex.toString()).append("\n");

--- a/cadc-util/build.gradle
+++ b/cadc-util/build.gradle
@@ -17,7 +17,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.3.2'
+version = '1.3.3'
 
 dependencies {
     compile 'log4j:log4j:1.2.17'

--- a/cadc-util/src/intTest/java/ca/nrc/cadc/net/HttpGetTest.java
+++ b/cadc-util/src/intTest/java/ca/nrc/cadc/net/HttpGetTest.java
@@ -121,7 +121,8 @@ public class HttpGetTest {
             dl.setHeadOnly(true);
             dl.run();
             Assert.assertEquals("response code", 200, dl.getResponseCode());
-            Assert.assertTrue("content-length == 0", dest.toByteArray().length == 0);
+            Assert.assertTrue("no bytes read", dest.toByteArray().length == 0); // did not actually read bytes
+            Assert.assertTrue("content-length", dl.getContentLength() > 0L);
             Assert.assertNotNull("content-type", dl.getContentType());
         } catch (Exception unexpected) {
             log.error("unexpected exception", unexpected);

--- a/cadc-util/src/main/java/ca/nrc/cadc/net/HttpGet.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/net/HttpGet.java
@@ -167,6 +167,23 @@ public class HttpGet extends HttpTransfer {
     }
 
     @Override
+    public void run() {
+        if (headOnly) {
+            if (failure == null) {
+                try {
+                    if (responseStream == null) {
+                        prepare();
+                    }
+                } catch (Throwable t) {
+                    this.failure = t;
+                }
+            }
+        } else {
+            super.run();
+        }
+    }
+
+    @Override
     protected void doAction()
             throws AccessControlException, NotAuthenticatedException,
             ByteLimitExceededException, ExpectationFailedException,


### PR DESCRIPTION
 tidy server output of IllegalArgumentException