### PR TITLE
CADC-8954: filter http response codes < 100 correctly in HttpTransfer.checkErrors()

### DIFF
--- a/cadc-util/build.gradle
+++ b/cadc-util/build.gradle
@@ -17,7 +17,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.3.12'
+version = '1.3.13'
 
 dependencies {
     compile 'log4j:log4j:1.2.17'

--- a/cadc-util/src/main/java/ca/nrc/cadc/net/HttpTransfer.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/net/HttpTransfer.java
@@ -760,7 +760,7 @@ public abstract class HttpTransfer implements Runnable {
         
         captureResponseHeaders(conn);
         
-        if (responseCode <= 100 && responseCode < 400) {
+        if (100 <= responseCode && responseCode < 400) {
             return;
         }
         log.debug("error: " + contentType + " " + contentLength);

--- a/cadc-util/src/main/java/ca/nrc/cadc/net/HttpTransfer.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/net/HttpTransfer.java
@@ -760,7 +760,7 @@ public abstract class HttpTransfer implements Runnable {
         
         captureResponseHeaders(conn);
         
-        if (responseCode < 400) {
+        if (responseCode <= 100 && responseCode < 400) {
             return;
         }
         log.debug("error: " + contentType + " " + contentLength);


### PR DESCRIPTION
The check for '-1' would never be reached because the filter only worked for >= 400 errors. 

Part for CADC-1289: make storage UI work against cavern.