### PR TITLE
Auth header changes

### DIFF
--- a/cadc-rest/build.gradle
+++ b/cadc-rest/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile 'commons-fileupload:commons-fileupload:1.4'
     compile 'log4j:log4j:1.2.17'
     compile 'javax.servlet:javax.servlet-api:3.1.0'
-    compile 'org.opencadc:cadc-util:[1.5.3,2.0)'
+    compile 'org.opencadc:cadc-util:[1.5.5,2.0)'
     compile 'org.opencadc:cadc-registry:[1.5,)'
 
     testCompile 'junit:junit:4.13'

--- a/cadc-rest/build.gradle
+++ b/cadc-rest/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.3.8'
+version = '1.3.9'
 
 description = 'OpenCADC REST server library'
 def git_url = 'https://github.com/opencadc/core'

--- a/cadc-rest/src/main/java/ca/nrc/cadc/rest/RestServlet.java
+++ b/cadc-rest/src/main/java/ca/nrc/cadc/rest/RestServlet.java
@@ -487,7 +487,8 @@ public class RestServlet extends HttpServlet {
                 URI loginServiceURI = getLocalServiceURI(Standards.SECURITY_METHOD_PASSWORD);
                 URL loginURL = regClient.getServiceURL(loginServiceURI, Standards.SECURITY_METHOD_PASSWORD, AuthMethod.ANON);
                 StringBuilder sb = new StringBuilder();
-                sb.append(AuthenticationUtil.CHALLENGE_TYPE_IVOA_BEARER + " standard_id=\"").append(Standards.SECURITY_METHOD_PASSWORD.toString()).append("\", ");
+                sb.append(AuthenticationUtil.CHALLENGE_TYPE_IVOA_BEARER + " standard_id=\"")
+                    .append(Standards.SECURITY_METHOD_PASSWORD.toString()).append("\", ");
                 sb.append("access_url=\"").append(loginURL).append("\"");
                 appendAuthenticateErrorInfo(AuthenticationUtil.CHALLENGE_TYPE_IVOA_BEARER, sb, ex, false);
                 out.addHeader(AuthenticationUtil.AUTHENTICATE_HEADER, sb.toString());
@@ -519,7 +520,8 @@ public class RestServlet extends HttpServlet {
                 URI cdpProxyServiceURI = getLocalServiceURI(Standards.CRED_PROXY_10);
                 URL cdpProxyURL = regClient.getServiceURL(cdpProxyServiceURI, Standards.CRED_PROXY_10, AuthMethod.PASSWORD);
                 StringBuilder sb = new StringBuilder();
-                sb.append(AuthenticationUtil.CHALLENGE_TYPE_IVOA_X509 + " standard_id=\"").append(Standards.SECURITY_METHOD_HTTP_BASIC.toASCIIString()).append("\", ");
+                sb.append(AuthenticationUtil.CHALLENGE_TYPE_IVOA_X509 + " standard_id=\"")
+                    .append(Standards.SECURITY_METHOD_HTTP_BASIC.toASCIIString()).append("\", ");
                 sb.append("access_url=\"").append(cdpProxyURL).append("\"");
                 out.addHeader(AuthenticationUtil.AUTHENTICATE_HEADER, sb.toString());
             } catch (NoSuchElementException notSupported) {

--- a/cadc-rest/src/main/java/ca/nrc/cadc/rest/RestServlet.java
+++ b/cadc-rest/src/main/java/ca/nrc/cadc/rest/RestServlet.java
@@ -334,7 +334,11 @@ public class RestServlet extends HttpServlet {
             logInfo.setSuccess(true);
             logInfo.setMessage(ex.getMessage());
             if (!authHeadersSet && setAuthHeaders) {
-                setAuthenticateHeaders(null, out, ex, response);
+                try {
+                    setAuthenticateHeaders(null, out, ex, response);
+                } catch (Throwable t) {
+                    log.warn("Failed to set www-authenticate headers", t);
+                }
             }
             handleException(out, response, ex, 401, ex.getMessage(), false);
         } catch (InstantiationException | IllegalAccessException ex) {
@@ -459,7 +463,7 @@ public class RestServlet extends HttpServlet {
             return;
         }
         
-        if (!subject.getPrincipals().isEmpty()) {
+        if (subject != null && !subject.getPrincipals().isEmpty()) {
             // Authenticated...
             
             log.debug("Setting " + AuthenticationUtil.VO_AUTHENTICATED_HEADER + " header");

--- a/cadc-rest/src/main/java/ca/nrc/cadc/rest/RestServlet.java
+++ b/cadc-rest/src/main/java/ca/nrc/cadc/rest/RestServlet.java
@@ -449,8 +449,25 @@ public class RestServlet extends HttpServlet {
             return;
         }
         
-        AuthMethod am = AuthenticationUtil.getAuthMethod(subject);
-        if (am == null || AuthMethod.ANON.equals(am)) {
+        if (!subject.getPrincipals().isEmpty()) {
+            
+            // Authenticated...
+            
+            log.debug("Setting " + AuthenticationUtil.VO_AUTHENTICATED_HEADER + " header");
+            Set<HttpPrincipal> useridPrincipals = subject.getPrincipals(HttpPrincipal.class);
+            if (!useridPrincipals.isEmpty()) {
+                HttpPrincipal userid = useridPrincipals.iterator().next();
+                out.addHeader(AuthenticationUtil.VO_AUTHENTICATED_HEADER, userid.getName());
+                return;
+            }
+            Set<Principal> allPrincipals = subject.getPrincipals();
+            if (!allPrincipals.isEmpty()) {
+                Principal principal = allPrincipals.iterator().next();
+                out.addHeader(AuthenticationUtil.VO_AUTHENTICATED_HEADER, principal.getName());
+                return;
+            }
+            
+        } else {
             // Not authenticated...
             
             log.debug("Setting " + AuthenticationUtil.AUTHENTICATE_HEADER + " header");
@@ -493,24 +510,6 @@ public class RestServlet extends HttpServlet {
             sb.append(AuthenticationUtil.CHALLENGE_TYPE_IVOA + " standard_id=\"").append(Standards.SECURITY_METHOD_CERT.toASCIIString()).append("\"");
             out.addHeader(AuthenticationUtil.AUTHENTICATE_HEADER, sb.toString());
             
-            
-            
-        } else {
-            // Authenticated...
-            
-            log.debug("Setting " + AuthenticationUtil.VO_AUTHENTICATED_HEADER + " header");
-            Set<HttpPrincipal> useridPrincipals = subject.getPrincipals(HttpPrincipal.class);
-            if (!useridPrincipals.isEmpty()) {
-                HttpPrincipal userid = useridPrincipals.iterator().next();
-                out.addHeader(AuthenticationUtil.VO_AUTHENTICATED_HEADER, userid.getName());
-                return;
-            }
-            Set<Principal> allPrincipals = subject.getPrincipals();
-            if (!allPrincipals.isEmpty()) {
-                Principal principal = allPrincipals.iterator().next();
-                out.addHeader(AuthenticationUtil.VO_AUTHENTICATED_HEADER, principal.getName());
-                return;
-            }
         }
     }
     

--- a/cadc-rest/src/test/java/ca/nrc/cadc/rest/RestServletTest.java
+++ b/cadc-rest/src/test/java/ca/nrc/cadc/rest/RestServletTest.java
@@ -74,20 +74,20 @@ import ca.nrc.cadc.auth.AuthorizationTokenPrincipal;
 import ca.nrc.cadc.auth.HttpPrincipal;
 import ca.nrc.cadc.auth.NotAuthenticatedException;
 import ca.nrc.cadc.auth.NotAuthenticatedException.AuthError;
+import ca.nrc.cadc.reg.AccessURL;
+import ca.nrc.cadc.reg.Capabilities;
+import ca.nrc.cadc.reg.Capability;
+import ca.nrc.cadc.reg.Interface;
 import ca.nrc.cadc.reg.Standards;
-import ca.nrc.cadc.reg.client.LocalAuthority;
 import ca.nrc.cadc.reg.client.RegistryClient;
 import ca.nrc.cadc.util.Log4jInit;
 
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.security.Principal;
 import java.util.ArrayList;
-import java.util.Set;
 
 import javax.security.auth.Subject;
-import javax.servlet.http.HttpServletResponse;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -152,7 +152,9 @@ public class RestServletTest {
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#OpenID\", access_url=\"https://example.com/ac/authorize\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv\"");
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv/basic\"");
+            EasyMock.expectLastCall().once();
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/cred/priv/pass\"");
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "Bearer");
             EasyMock.expectLastCall().once();
@@ -166,7 +168,9 @@ public class RestServletTest {
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#OpenID\", access_url=\"https://example.com/ac/authorize\", error=\"insufficient_scope\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv\"");
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv/basic\"");
+            EasyMock.expectLastCall().once();
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/cred/priv/pass\"");
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "Bearer");
             EasyMock.expectLastCall().once();
@@ -181,7 +185,9 @@ public class RestServletTest {
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#OpenID\", access_url=\"https://example.com/ac/authorize\", error=\"insufficient_scope\", error_description=\"text\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv\"");
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv/basic\"");
+            EasyMock.expectLastCall().once();
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/cred/priv/pass\"");
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "Bearer");
             EasyMock.expectLastCall().once();
@@ -196,7 +202,9 @@ public class RestServletTest {
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#OpenID\", access_url=\"https://example.com/ac/authorize\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv\"");
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv/basic\"");
+            EasyMock.expectLastCall().once();
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/cred/priv/pass\"");
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "Bearer error=\"insufficient_scope\"");
             EasyMock.expectLastCall().once();
@@ -211,7 +219,9 @@ public class RestServletTest {
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#OpenID\", access_url=\"https://example.com/ac/authorize\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv\"");
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv/basic\"");
+            EasyMock.expectLastCall().once();
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/cred/priv/pass\"");
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "Bearer error=\"insufficient_scope\", error_description=\"text\"");
             EasyMock.expectLastCall().once();
@@ -235,6 +245,7 @@ public class RestServletTest {
         EasyMock.reset(mockOut);
     }
     
+    @SuppressWarnings("serial")
     public class TestRestServlet extends RestServlet {
        @Override
        RegistryClient getRegistryClient() {
@@ -252,14 +263,29 @@ public class RestServletTest {
             try {
                 if (securityMethod.equals(Standards.SECURITY_METHOD_PASSWORD)) {
                     return new URL("https://example.com/ac/login");
-                } else if (securityMethod.equals(Standards.CRED_PROXY_10)) {
-                    return new URL("https://example.com/cred/priv");
                 } else { 
                     return new URL("https://example.com/ac/authorize");
                 }
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }
+        }
+        
+        @Override
+        public Capabilities getCapabilities(URI resourceID) throws MalformedURLException {
+            Capabilities caps = new Capabilities();
+            Capability cap = new Capability(Standards.CRED_PROXY_10);
+            Interface ifc = new Interface(Standards.INTERFACE_PARAM_HTTP, new AccessURL(new URL("https://example.com/cred/priv/basic")));
+            ifc.getSecurityMethods().add(Standards.SECURITY_METHOD_HTTP_BASIC);
+            Interface ifc2 = new Interface(Standards.INTERFACE_PARAM_HTTP, new AccessURL(new URL("https://example.com/cred/priv/pass")));
+            ifc2.getSecurityMethods().add(Standards.SECURITY_METHOD_PASSWORD);
+            Interface ifc3 = new Interface(Standards.INTERFACE_PARAM_HTTP, new AccessURL(new URL("https://example.com/cred/priv/cookie")));
+            ifc2.getSecurityMethods().add(Standards.SECURITY_METHOD_COOKIE);
+            cap.getInterfaces().add(ifc);
+            cap.getInterfaces().add(ifc2);
+            cap.getInterfaces().add(ifc3);
+            caps.getCapabilities().add(cap);
+            return caps;
         }
         
     }

--- a/cadc-rest/src/test/java/ca/nrc/cadc/rest/RestServletTest.java
+++ b/cadc-rest/src/test/java/ca/nrc/cadc/rest/RestServletTest.java
@@ -148,66 +148,76 @@ public class RestServletTest {
             
             // no errors, all headers
             s = new Subject();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/ac/login\"");
+            out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/ac/login\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#OAuth\", access_url=\"https://example.com/ac/authorize\"");
+            out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#OpenID\", access_url=\"https://example.com/ac/authorize\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#tls-with-certificate\"");
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv\"");
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "Bearer");
+            EasyMock.expectLastCall().once();
+            out.addHeader("WWW-Authenticate", "ivoa_x509");
             EasyMock.expectLastCall().once();
             runTest(s, out, null);
             
             // ivoa token error no description
             s = new Subject();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/ac/login\", error=\"insufficient_scope\"");
+            out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/ac/login\", error=\"insufficient_scope\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#OAuth\", access_url=\"https://example.com/ac/authorize\", error=\"insufficient_scope\"");
+            out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#OpenID\", access_url=\"https://example.com/ac/authorize\", error=\"insufficient_scope\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#tls-with-certificate\"");
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv\"");
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "Bearer");
             EasyMock.expectLastCall().once();
-            NotAuthenticatedException ex = new NotAuthenticatedException("ivoa", AuthError.INSUFFICIENT_SCOPE, null);
+            out.addHeader("WWW-Authenticate", "ivoa_x509");
+            EasyMock.expectLastCall().once();
+            NotAuthenticatedException ex = new NotAuthenticatedException("ivoa_bearer", AuthError.INSUFFICIENT_SCOPE, null);
             runTest(s, out, ex);
             
             // ivoa token error with description
             s = new Subject();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/ac/login\", error=\"insufficient_scope\", error_description=\"text\"");
+            out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/ac/login\", error=\"insufficient_scope\", error_description=\"text\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#OAuth\", access_url=\"https://example.com/ac/authorize\", error=\"insufficient_scope\", error_description=\"text\"");
+            out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#OpenID\", access_url=\"https://example.com/ac/authorize\", error=\"insufficient_scope\", error_description=\"text\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#tls-with-certificate\"");
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv\"");
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "Bearer");
             EasyMock.expectLastCall().once();
-            ex = new NotAuthenticatedException("ivoa", AuthError.INSUFFICIENT_SCOPE, "text");
+            out.addHeader("WWW-Authenticate", "ivoa_x509");
+            EasyMock.expectLastCall().once();
+            ex = new NotAuthenticatedException("ivoa_bearer", AuthError.INSUFFICIENT_SCOPE, "text");
             runTest(s, out, ex);
             
             // bearer token error no description
             s = new Subject();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/ac/login\"");
+            out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/ac/login\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#OAuth\", access_url=\"https://example.com/ac/authorize\"");
+            out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#OpenID\", access_url=\"https://example.com/ac/authorize\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#tls-with-certificate\"");
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv\"");
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "Bearer error=\"insufficient_scope\"");
             EasyMock.expectLastCall().once();
             ex = new NotAuthenticatedException("Bearer", AuthError.INSUFFICIENT_SCOPE, null);
+            out.addHeader("WWW-Authenticate", "ivoa_x509");
+            EasyMock.expectLastCall().once();
             runTest(s, out, ex);
             
             // bearer token error with description
             s = new Subject();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/ac/login\"");
+            out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#tls-with-password\", access_url=\"https://example.com/ac/login\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#OAuth\", access_url=\"https://example.com/ac/authorize\"");
+            out.addHeader("WWW-Authenticate", "ivoa_bearer standard_id=\"ivo://ivoa.net/sso#OpenID\", access_url=\"https://example.com/ac/authorize\"");
             EasyMock.expectLastCall().once();
-            out.addHeader("WWW-Authenticate", "ivoa standard_id=\"ivo://ivoa.net/sso#tls-with-certificate\"");
+            out.addHeader("WWW-Authenticate", "ivoa_x509 standard_id=\"ivo://ivoa.net/sso#BasicAA\", access_url=\"https://example.com/cred/priv\"");
             EasyMock.expectLastCall().once();
             out.addHeader("WWW-Authenticate", "Bearer error=\"insufficient_scope\", error_description=\"text\"");
             EasyMock.expectLastCall().once();
             ex = new NotAuthenticatedException("Bearer", AuthError.INSUFFICIENT_SCOPE, "text");
+            out.addHeader("WWW-Authenticate", "ivoa_x509");
+            EasyMock.expectLastCall().once();
             runTest(s, out, ex);
 
         } catch (Exception unexpected) {
@@ -242,7 +252,9 @@ public class RestServletTest {
             try {
                 if (securityMethod.equals(Standards.SECURITY_METHOD_PASSWORD)) {
                     return new URL("https://example.com/ac/login");
-                } else {
+                } else if (securityMethod.equals(Standards.CRED_PROXY_10)) {
+                    return new URL("https://example.com/cred/priv");
+                } else { 
                     return new URL("https://example.com/ac/authorize");
                 }
             } catch (MalformedURLException e) {

--- a/cadc-util/build.gradle
+++ b/cadc-util/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.5.4'
+version = '1.5.5'
 
 description = 'OpenCADC core utility library'
 def git_url = 'https://github.com/opencadc/core'

--- a/cadc-util/src/main/java/ca/nrc/cadc/auth/AuthenticationUtil.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/auth/AuthenticationUtil.java
@@ -124,8 +124,9 @@ public class AuthenticationUtil {
     public static final String VO_AUTHENTICATED_HEADER = "x-vo-authenticated";
     
     public static final String CHALLENGE_TYPE_BEARER = "Bearer";
-    public static final String CHALLENGE_TYPE_IVOA = "ivoa";
     public static final String CHALLENGE_TYPE_BASIC = "Basic";
+    public static final String CHALLENGE_TYPE_IVOA_BEARER = "ivoa_bearer";
+    public static final String CHALLENGE_TYPE_IVOA_X509 = "ivoa_x509";
     @Deprecated
     public static final String TOKEN_TYPE_CADC = AUTH_HEADER;
 

--- a/cadc-util/src/main/java/ca/nrc/cadc/auth/TokenValidator.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/auth/TokenValidator.java
@@ -137,8 +137,7 @@ public class TokenValidator {
                 }
                 challengeType = p.getHeaderValue().substring(0, spaceIndex).trim();
                 credentials = p.getHeaderValue().substring(spaceIndex + 1).trim();
-                if (!AuthenticationUtil.CHALLENGE_TYPE_BEARER.equalsIgnoreCase(challengeType)
-                    && !AuthenticationUtil.CHALLENGE_TYPE_IVOA.equalsIgnoreCase(challengeType)) {
+                if (!AuthenticationUtil.CHALLENGE_TYPE_BEARER.equalsIgnoreCase(challengeType)) {
                     throw new NotAuthenticatedException(challengeType, AuthError.INVALID_REQUEST,
                         "unsupported challenge type: " + challengeType);
                 }

--- a/cadc-util/src/test/java/ca/nrc/cadc/auth/TokenValidatorTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/auth/TokenValidatorTest.java
@@ -160,12 +160,11 @@ public class TokenValidatorTest {
             value = SignedToken.format(token);
             authPrincipal = new AuthorizationTokenPrincipal(AuthenticationUtil.AUTHORIZATION_HEADER, "ivoa " + value);
             subject.getPrincipals().add(authPrincipal);
-            subject = TokenValidator.validateTokens(subject);
-            Assert.assertEquals("token credential", 1, subject.getPublicCredentials(AuthorizationToken.class).size());
-            authToken = subject.getPublicCredentials(AuthorizationToken.class).iterator().next();
-            Assert.assertEquals("ivoa token type", AuthenticationUtil.CHALLENGE_TYPE_IVOA, authToken.getType());
-            Assert.assertEquals("ivoa token value", value, authToken.getCredentials());
-            Assert.assertEquals("ivoa token scope", "the:scope", authToken.getScope().toString());
+            try {
+                subject = TokenValidator.validateTokens(subject);
+            } catch (NotAuthenticatedException ex) {
+                Assert.assertTrue("exception message", ex.getMessage().contains("unsupported challenge type: ivoa"));
+            }
             
             // invalid bearer token
             subject = new Subject();
@@ -176,18 +175,6 @@ public class TokenValidatorTest {
                 Assert.fail("Should have received NotAuthenticatedException");
             } catch (NotAuthenticatedException e) {
                 Assert.assertEquals(AuthenticationUtil.CHALLENGE_TYPE_BEARER, e.getChallenge());
-                Assert.assertEquals("invalid_token", e.getAuthError().getValue());
-            }
-            
-            // invalid ivoa token
-            subject = new Subject();
-            authPrincipal = new AuthorizationTokenPrincipal(AuthenticationUtil.AUTHORIZATION_HEADER, "ivoa tampered");
-            subject.getPrincipals().add(authPrincipal);
-            try {
-                subject = TokenValidator.validateTokens(subject);
-                Assert.fail("Should have received NotAuthenticatedException");
-            } catch (NotAuthenticatedException e) {
-                Assert.assertEquals(AuthenticationUtil.CHALLENGE_TYPE_IVOA, e.getChallenge());
                 Assert.assertEquals("invalid_token", e.getAuthError().getValue());
             }
             


### PR DESCRIPTION
note: the new `setAuthHeaders` boolean is there to prevent the infinite lookup loop that happens in the 2 credential issuing services:  ac and cred.