### PR TITLE
Added failure for PropertiesReader

### DIFF
--- a/cadc-util/build.gradle
+++ b/cadc-util/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.6.7'
+version = '1.7.0'
 
 description = 'OpenCADC core utility library'
 def git_url = 'https://github.com/opencadc/core'

--- a/cadc-util/src/main/java/ca/nrc/cadc/util/InvalidConfigException.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/util/InvalidConfigException.java
@@ -1,0 +1,85 @@
+/*
+************************************************************************
+*******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+**************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+*
+*  (c) 2020.                            (c) 2020.
+*  Government of Canada                 Gouvernement du Canada
+*  National Research Council            Conseil national de recherches
+*  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+*  All rights reserved                  Tous droits réservés
+*
+*  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+*  expressed, implied, or               énoncée, implicite ou légale,
+*  statutory, of any kind with          de quelque nature que ce
+*  respect to the software,             soit, concernant le logiciel,
+*  including without limitation         y compris sans restriction
+*  any warranty of merchantability      toute garantie de valeur
+*  or fitness for a particular          marchande ou de pertinence
+*  purpose. NRC shall not be            pour un usage particulier.
+*  liable in any event for any          Le CNRC ne pourra en aucun cas
+*  damages, whether direct or           être tenu responsable de tout
+*  indirect, special or general,        dommage, direct ou indirect,
+*  consequential or incidental,         particulier ou général,
+*  arising from the use of the          accessoire ou fortuit, résultant
+*  software.  Neither the name          de l'utilisation du logiciel. Ni
+*  of the National Research             le nom du Conseil National de
+*  Council of Canada nor the            Recherches du Canada ni les noms
+*  names of its contributors may        de ses  participants ne peuvent
+*  be used to endorse or promote        être utilisés pour approuver ou
+*  products derived from this           promouvoir les produits dérivés
+*  software without specific prior      de ce logiciel sans autorisation
+*  written permission.                  préalable et particulière
+*                                       par écrit.
+*
+*  This file is part of the             Ce fichier fait partie du projet
+*  OpenCADC project.                    OpenCADC.
+*
+*  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+*  you can redistribute it and/or       vous pouvez le redistribuer ou le
+*  modify it under the terms of         modifier suivant les termes de
+*  the GNU Affero General Public        la “GNU Affero General Public
+*  License as published by the          License” telle que publiée
+*  Free Software Foundation,            par la Free Software Foundation
+*  either version 3 of the              : soit la version 3 de cette
+*  License, or (at your option)         licence, soit (à votre gré)
+*  any later version.                   toute version ultérieure.
+*
+*  OpenCADC is distributed in the       OpenCADC est distribué
+*  hope that it will be useful,         dans l’espoir qu’il vous
+*  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+*  without even the implied             GARANTIE : sans même la garantie
+*  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+*  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+*  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+*  General Public License for           Générale Publique GNU Affero
+*  more details.                        pour plus de détails.
+*
+*  You should have received             Vous devriez avoir reçu une
+*  a copy of the GNU Affero             copie de la Licence Générale
+*  General Public License along         Publique GNU Affero avec
+*  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+*  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+*                                       <http://www.gnu.org/licenses/>.
+*
+************************************************************************
+*/
+
+package ca.nrc.cadc.util;
+
+/**
+ * Thrown if an application's configuration is not valid.  This is implemented as a RuntimeException as the
+ * assumption is that CADC applications that expect configuration cannot proceed without it.
+ * 
+ * @author pdowler
+ */
+public class InvalidConfigException extends RuntimeException {
+
+    public InvalidConfigException(String msg) { 
+        super(msg);
+    }
+
+    public InvalidConfigException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/cadc-util/src/main/java/ca/nrc/cadc/util/PropertiesReader.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/util/PropertiesReader.java
@@ -30,8 +30,10 @@ package ca.nrc.cadc.util;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,7 +78,7 @@ public class PropertiesReader {
      *
      * @param filename The file in which to read.
      */
-    public PropertiesReader(String filename) {
+    public PropertiesReader(String filename) throws FileNotFoundException, IllegalArgumentException {
         if (filename == null) {
             throw new IllegalArgumentException("fileName cannot be null.");
         }
@@ -91,9 +93,13 @@ public class PropertiesReader {
         cachedPropsKey = propertiesFile.getAbsolutePath();
         log.debug("properties file: " + propertiesFile);
         
-        if (!canRead()) {
-            log.warn("File at " + propertiesFile + " does not exist or is unusable.");
+        if (!propertiesFile.exists()) {
+            throw new FileNotFoundException("No such file: " + this.cachedPropsKey);
+        } else if (!Files.isReadable(propertiesFile.toPath())) {
+            throw new IllegalArgumentException("Unreadable or unusable file: " + this.cachedPropsKey);
         }
+
+        log.debug("PropertiesReader.init: OK");
     }
 
     /**

--- a/cadc-util/src/main/java/ca/nrc/cadc/util/PropertiesReader.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/util/PropertiesReader.java
@@ -77,10 +77,9 @@ public class PropertiesReader {
      * 2) Otherwise, the file will be read from ${user.home}/config/
      *
      * @param filename The file in which to read.
-     * @throws IOException If the properties file cannot be found (FileNotFoundException) or cannot be
-     *                      read (IOException).
+     * @throws InvalidConfigException If the properties file cannot be found or cannot be read.
      */
-    public PropertiesReader(String filename) throws IOException {
+    public PropertiesReader(String filename) throws InvalidConfigException {
         if (filename == null) {
             throw new IllegalArgumentException("fileName cannot be null.");
         }
@@ -90,15 +89,14 @@ public class PropertiesReader {
             configDir = System.getProperty(CONFIG_DIR_SYSTEM_PROPERTY);
         }
 
-        
         propertiesFile = new File(new File(configDir), filename);
         cachedPropsKey = propertiesFile.getAbsolutePath();
         log.debug("properties file: " + propertiesFile);
         
         if (!propertiesFile.exists()) {
-            throw new FileNotFoundException("No such file: " + this.cachedPropsKey);
-        } else if (!Files.isReadable(propertiesFile.toPath())) {
-            throw new IOException("Unreadable or unusable file: " + this.cachedPropsKey);
+            throw new InvalidConfigException("No such file: " + this.cachedPropsKey);
+        } else if (!canRead()) {
+            throw new InvalidConfigException("Unreadable or unusable file: " + this.cachedPropsKey);
         }
 
         log.debug("PropertiesReader.init: OK");
@@ -109,7 +107,7 @@ public class PropertiesReader {
      * @return  True if the provided file exists in the constrained locations and can be read.  False otherwise.
      */
     public boolean canRead() {
-        return propertiesFile.exists() && propertiesFile.isFile() && propertiesFile.canRead();
+        return Files.isReadable(this.propertiesFile.toPath());
     }
 
     /**

--- a/cadc-util/src/main/java/ca/nrc/cadc/util/PropertiesReader.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/util/PropertiesReader.java
@@ -77,8 +77,10 @@ public class PropertiesReader {
      * 2) Otherwise, the file will be read from ${user.home}/config/
      *
      * @param filename The file in which to read.
+     * @throws IOException If the properties file cannot be found (FileNotFoundException) or cannot be
+     *                      read (IOException).
      */
-    public PropertiesReader(String filename) throws FileNotFoundException, IllegalArgumentException {
+    public PropertiesReader(String filename) throws IOException {
         if (filename == null) {
             throw new IllegalArgumentException("fileName cannot be null.");
         }
@@ -96,7 +98,7 @@ public class PropertiesReader {
         if (!propertiesFile.exists()) {
             throw new FileNotFoundException("No such file: " + this.cachedPropsKey);
         } else if (!Files.isReadable(propertiesFile.toPath())) {
-            throw new IllegalArgumentException("Unreadable or unusable file: " + this.cachedPropsKey);
+            throw new IOException("Unreadable or unusable file: " + this.cachedPropsKey);
         }
 
         log.debug("PropertiesReader.init: OK");

--- a/cadc-util/src/main/java/ca/nrc/cadc/util/RsaSignatureVerifier.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/util/RsaSignatureVerifier.java
@@ -119,7 +119,7 @@ public class RsaSignatureVerifier {
     protected static RsaSignatureVerifier inst;
     protected Set<PublicKey> pubKeys = new HashSet<PublicKey>();
     protected static final String KEY_ALGORITHM = "RSA";
-    protected static final String SIG_ALGORITHM = "SHA1withRSA";
+    protected static final String SIG_ALGORITHM = "SHA256withRSA";
     
     public static final String PUB_KEY_FILE_NAME = "RsaSignaturePub.key";
             
@@ -259,7 +259,7 @@ public class RsaSignatureVerifier {
                     "No public keys available for verifying");
         }
         try {       
-            Set<Signature> sigs = new HashSet<Signature>(pubKeys.size());
+            Set<Signature> sigs = new HashSet<>(pubKeys.size());
             for (PublicKey pubKey : pubKeys) {
                 Signature sig = getSignature();
                 sig.initVerify(pubKey);

--- a/cadc-util/src/test/java/ca/nrc/cadc/util/PropertiesReaderTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/util/PropertiesReaderTest.java
@@ -31,6 +31,8 @@ package ca.nrc.cadc.util;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.Assert;
@@ -132,9 +134,31 @@ public class PropertiesReaderTest
     }
 
     @Test
-    public void testCanNotRead() {
-        final PropertiesReader testSubject = new PropertiesReader("BOGUSFILE.nope");
-        Assert.assertFalse("Should return false readability.", testSubject.canRead());
+    public void testCanNotRead() throws Exception {
+        System.setProperty(PropertiesReader.class.getName() + ".dir", getTestConfigDir());
+        final File propFilePath = Files.createTempFile(new File(getTestConfigDir()).toPath(),
+                                                       "willNotBeReadable", ".properties").toFile();
+        propFilePath.setReadable(false);
+        propFilePath.setExecutable(false, false);
+
+        try {
+            new PropertiesReader(propFilePath.getName());
+            Assert.fail("Should throw IllegalArgumentException.");
+        } catch (IllegalArgumentException illegalArgumentException) {
+            // Good.
+        } finally {
+            System.clearProperty(PropertiesReader.class.getName() + ".dir");
+        }
+    }
+
+    @Test
+    public void testDoesNotExist() {
+        try {
+            new PropertiesReader("BOGUSFILE.nope");
+            Assert.fail("Should throw FileNotFoundException.");
+        } catch (FileNotFoundException fileNotFoundException) {
+            // Good.
+        }
     }
 
     @Test

--- a/cadc-util/src/test/java/ca/nrc/cadc/util/PropertiesReaderTest.java
+++ b/cadc-util/src/test/java/ca/nrc/cadc/util/PropertiesReaderTest.java
@@ -31,6 +31,7 @@ package ca.nrc.cadc.util;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -144,7 +145,7 @@ public class PropertiesReaderTest
         try {
             new PropertiesReader(propFilePath.getName());
             Assert.fail("Should throw IllegalArgumentException.");
-        } catch (IllegalArgumentException illegalArgumentException) {
+        } catch (IOException ioException) {
             // Good.
         } finally {
             System.clearProperty(PropertiesReader.class.getName() + ".dir");
@@ -156,7 +157,9 @@ public class PropertiesReaderTest
         try {
             new PropertiesReader("BOGUSFILE.nope");
             Assert.fail("Should throw FileNotFoundException.");
-        } catch (FileNotFoundException fileNotFoundException) {
+        } catch (IOException fileNotFoundException) {
+            Assert.assertTrue("Should be FileNotFoundException.",
+                              fileNotFoundException instanceof FileNotFoundException);
             // Good.
         }
     }


### PR DESCRIPTION
WIP

Bumped version to 1.7.0 as new errors are introduced.

The Storage Inventory issue (https://github.com/opencadc/storage-inventory/issues/256) drove this.  This simply throws an `IOException` (potentially `FileNotFoundException`) rather than a simple `warning`.