### PR TITLE
Alt auth access

### DIFF
--- a/cadc-log/build.gradle
+++ b/cadc-log/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.1.6'
+version = '1.1.7'
 
 description = 'OpenCADC Logging Init server library'
 def git_url = 'https://github.com/opencadc/core'

--- a/cadc-log/src/main/java/ca/nrc/cadc/log/LogControlServlet.java
+++ b/cadc-log/src/main/java/ca/nrc/cadc/log/LogControlServlet.java
@@ -376,10 +376,6 @@ public class LogControlServlet extends HttpServlet {
             url = url + "?" + SECRET_PROPERTY + "=" + secretQuery;
         }
 
-        if (StringUtil.hasLength(request.getHeader("Authorization"))) {
-            response.setHeader("Authorization", request.getHeader("Authorization"));
-        }
-
         response.setHeader("Location", url);
     }
 

--- a/cadc-log/src/main/java/ca/nrc/cadc/log/LogControlServlet.java
+++ b/cadc-log/src/main/java/ca/nrc/cadc/log/LogControlServlet.java
@@ -384,6 +384,10 @@ public class LogControlServlet extends HttpServlet {
             response.setHeader(REQUEST_HEADER_SECRET_KEY, secretHeader);
         }
 
+        if (StringUtil.hasLength(request.getHeader("Authorization"))) {
+            response.setHeader("Authorization", request.getHeader("Authorization"));
+        }
+
         response.setHeader("Location", url);
     }
 
@@ -525,7 +529,8 @@ public class LogControlServlet extends HttpServlet {
      */
     private boolean isAuthorizedUser(Subject subject, Set<Principal> authorizedUsers) {
         if (!authorizedUsers.isEmpty()) {
-            Set<X500Principal> principals = subject.getPrincipals(X500Principal.class);
+            // Allow all principals to be checked.
+            Set<Principal> principals = subject.getPrincipals(Principal.class);
             for (Principal caller : principals) {
                 for (Principal authorizedUser : authorizedUsers) {
                     if (AuthenticationUtil.equals(authorizedUser, caller)) {

--- a/cadc-log/src/main/java/ca/nrc/cadc/log/LogControlServlet.java
+++ b/cadc-log/src/main/java/ca/nrc/cadc/log/LogControlServlet.java
@@ -170,7 +170,6 @@ public class LogControlServlet extends HttpServlet {
     static final String GROUP_URIS_PROPERTY = "group";
     static final String USERNAME_PROPERTY = "username";
     static final String SECRET_PROPERTY = "secret";
-    static final String REQUEST_HEADER_SECRET_KEY = "x-cadc-logcontrol";
 
     private Level level = null;
     private List<String> packages;
@@ -371,17 +370,10 @@ public class LogControlServlet extends HttpServlet {
         response.setStatus(HttpServletResponse.SC_SEE_OTHER);
         String url = request.getRequestURI();
 
-        // We could condense this and just redirect to one of them, but it seems more proper to just carry forward what
-        // the caller submitted.
         String secretQuery = request.getParameter(SECRET_PROPERTY);
-        String secretHeader = request.getHeader(REQUEST_HEADER_SECRET_KEY);
 
         if (StringUtil.hasLength(secretQuery)) {
             url = url + "?" + SECRET_PROPERTY + "=" + secretQuery;
-        }
-
-        if (StringUtil.hasLength(secretHeader)) {
-            response.setHeader(REQUEST_HEADER_SECRET_KEY, secretHeader);
         }
 
         if (StringUtil.hasLength(request.getHeader("Authorization"))) {
@@ -507,13 +499,11 @@ public class LogControlServlet extends HttpServlet {
      * @return      True if a provided secret matches a configured one.  False otherwise.
      */
     private boolean isAuthorizedSecret(HttpServletRequest request, MultiValuedProperties multiValuedProperties) {
-        String requestHeaderSecret = request.getHeader(LogControlServlet.REQUEST_HEADER_SECRET_KEY);
         String requestParamSecret = request.getParameter(LogControlServlet.SECRET_PROPERTY);
-
         List<String> configuredSecrets = multiValuedProperties.getProperty(SECRET_PROPERTY);
         for (String configuredSecret : configuredSecrets) {
             // Intentionally kept as case-sensitive.
-            if (configuredSecret.equals(requestHeaderSecret) || configuredSecret.equals(requestParamSecret)) {
+            if (configuredSecret.equals(requestParamSecret)) {
                 return true;
             }
         }


### PR DESCRIPTION
Allow for BASIC authentication (username/password) with `username` key specified in the log properties file.
Allow for Secret key access with `secret` key specified in the log properties file.  Can be set as a request parameter with `?secret=` or as a request header (`x-cadc-logcontrol`).