### PR TITLE
cadc-vodml: pull published vodml xsd

### DIFF
--- a/cadc-vodml/build.gradle
+++ b/cadc-vodml/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.0.9'
+version = '1.0.10'
 
 description = 'OpenCADC VO-DML validation library'
 def git_url = 'https://github.com/opencadc/core'

--- a/cadc-vodml/src/main/resources/vo-dml-v1.0.xsd
+++ b/cadc-vodml/src/main/resources/vo-dml-v1.0.xsd
@@ -332,11 +332,6 @@ TBD continue based on VO-DML specification document.
                 </xsd:annotation>
             </xsd:element>
         </xsd:sequence>
-        <xsd:attribute name="version" type="xsd:string" use="optional">
-            <xsd:annotation>
-                <xsd:documentation>The major.minor version this VO-DML document.</xsd:documentation>
-            </xsd:annotation>
-        </xsd:attribute>
     </xsd:complexType>
 
 

--- a/cadc-vodml/src/test/java/ca/nrc/cadc/vodml/VOModelReaderTest.java
+++ b/cadc-vodml/src/test/java/ca/nrc/cadc/vodml/VOModelReaderTest.java
@@ -138,7 +138,8 @@ public class VOModelReaderTest {
         }
     }
     
-    @Test
+    //@Test
+    // version attribute was removed from the current xsd on ivoa.net
     public void testVersionAttrSchemaValid() {
         try {
             File testVODML = FileUtil.getFileFromResource(VALID_VERSION_VODML_FILE, VOModelReaderTest.class);


### PR DESCRIPTION
disable tests that check version attribute that is not in the xsd