### PR TITLE
cadc-util-1.12.2: change single connection data source to supress close by default

### DIFF
--- a/cadc-util/build.gradle
+++ b/cadc-util/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.12.1'
+version = '1.12.2'
 
 description = 'OpenCADC core utility library'
 def git_url = 'https://github.com/opencadc/core'

--- a/cadc-util/src/main/java/ca/nrc/cadc/db/DBUtil.java
+++ b/cadc-util/src/main/java/ca/nrc/cadc/db/DBUtil.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2016.                            (c) 2016.
+*  (c) 2025.                            (c) 2025.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -73,13 +73,11 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.Properties;
-
 import javax.management.ObjectName;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
-
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.apache.commons.dbcp2.PoolableConnectionFactory;
@@ -103,23 +101,22 @@ public class DBUtil {
     public static String DEFAULT_JNDI_ENV_CONTEXT = "java:/comp/env";
 
     /**
-     * Create a DataSource with a single connection to the server. The DataSource is
-     * tested before return. All failures are thrown as RuntimeException with a
-     * Throwable (cause).
+     * Create a DataSource with a single connection to the server. Defaults to 
+     * suppressClose==true and test==true.
      *
-     * @param config
+     * @param config connection configuration info
      * @return a connected single connection DataSource
      * @throws DBConfigException
      */
     public static DataSource getDataSource(ConnectionConfig config) throws DBConfigException {
-        return getDataSource(config, false, true);
+        return getDataSource(config, true, true);
     }
 
     /**
      * Create a DataSource with a single connection to the server. All failures are
      * thrown as RuntimeException with a Throwable (cause).
      *
-     * @param config
+     * @param config connection configuration info
      * @param suppressClose suppress close calls on the underlying Connection
      * @param test          test the datasource before return (might throw)
      * @return a connected single connection DataSource

--- a/opencadc.gradle
+++ b/opencadc.gradle
@@ -28,17 +28,16 @@ sourceSets {
 
 // Temporary work around for issue https://github.com/gradle/gradle/issues/881 - 
 // gradle not displaying fail build status when warnings reported -->
-
-//tasks.withType(Checkstyle).each { checkstyleTask ->
-//    checkstyleTask.doLast {
-//        reports.all { report ->
-//            def outputFile = report.destination
-//            if (outputFile.exists() && outputFile.text.contains("<error ")) {
-//                throw new GradleException("There were checkstyle warnings! For more info check $outputFile")
-//            }
-//        }
-//    }
-//}
+tasks.withType(Checkstyle).each { checkstyleTask ->
+    checkstyleTask.doLast {
+        reports.all { report ->
+            def outputFile = report.destination
+            if (outputFile.exists() && outputFile.text.contains("<error ")) {
+                throw new GradleException("There were checkstyle warnings! For more info check $outputFile")
+            }
+        }
+    }
+}
 
 tasks.withType(Test) {
     // reset the report destinations so that intTests go to their own page


### PR DESCRIPTION


re-include work around so checkstyle errors cause build to fail