### PR TITLE
fix: only consider bearer and basic tokens to be unvalidated if skipped

### DIFF
--- a/cadc-util/build.gradle
+++ b/cadc-util/build.gradle
@@ -15,7 +15,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.12.7'
+version = '1.12.8'
 
 description = 'OpenCADC core utility library'
 def git_url = 'https://github.com/opencadc/core'


### PR DESCRIPTION
This change is to ignore Token Principals that are not `Bearer` or `Basic` if left invalidated.  Custom tokens won't turn into Credentials.